### PR TITLE
Add Analyze Attack Button + small fixes

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1,0 +1,12 @@
+<?php
+
+if (!function_exists('attack_broadcastable')) {
+    /**
+     * Returns true if an attack is allowed to be broadcasted.
+     * Examples of restrictions could be if its already in the news
+     * Or if it is too old.
+     * */
+    function attack_broadcastable($attack) {
+        return (!$attack->isNews && $attack->created_at->diffInDays() <= 3);
+    }
+}

--- a/app/Http/Controllers/BlueTeamController.php
+++ b/app/Http/Controllers/BlueTeamController.php
@@ -42,6 +42,7 @@ class BlueTeamController extends Controller {
             switch ($page) {
                 case 'home': return $this->home(); break;
                 case 'broadcast': return $this->broadcast($request); break;
+                case 'analyzeAttack': return $this->analyzeAttack($request); break;
                 case 'clearNotifs': return $this->clearNotifs(); break;
                 case 'news': return $this->news(); break;
                 case 'attacks': return $this->attacks(); break;
@@ -258,6 +259,13 @@ class BlueTeamController extends Controller {
         $attack->setNews(true);
         $attack->setNotified(true);
         return $this->home();
+    }
+
+    public function analyzeAttack(request $request) {
+        $attID = $request->attID;
+        $attack = Attack::find($attID);
+        $attack->analyze();
+        return $this->attacks();
     }
 
     public function clearNotifs() {

--- a/app/Models/Assets/SecurityAnalystAsset.php
+++ b/app/Models/Assets/SecurityAnalystAsset.php
@@ -11,6 +11,7 @@ class SecurityAnalystAsset extends Asset
     public $_tags    = ['Analysis', 'TurnConsumable'];
     public $_blue = 1;
     public $_buyable = 1;
+    public $_purchase_cost = 300;
 
     public function onPreAttack($attack)
     {

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -240,6 +240,17 @@ class Attack extends Model
         Attack::updateAttack($this);
     }
 
+    public function analyze() {
+        $blue = Team::find($this->blueteam);
+        if ($blue->balance < 500) {
+            return false;
+        }
+        $blue->changeBalance(-500);
+        $this->detection_level = 2;
+        Attack::updateAttack($this);
+        return true;
+    }
+
     public function changeDifficulty($val){
         $this->difficulty += $val;
         if($this->difficulty > 5) $this->difficulty = 5;

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -91,6 +91,7 @@ class Attack extends Model
         try {
             $class = "\\App\\Models\\Attacks\\" . $attack->class_name . "Attack";
             $att = new $class();
+            $att->id = $attack->id;
             $att->name = $attack->name;
             $att->class_name = $attack->class_name;
             $att->energy_cost = $attack->energy_cost;
@@ -125,7 +126,7 @@ class Attack extends Model
             $attack = new $class();
             $attack->blueteam = $blueID;
             $attack->redteam = $redID;
-            Attack::store($attack);
+            $attack = Attack::store($attack);
             return $attack;
         }
         catch(Error $e) {
@@ -161,11 +162,7 @@ class Attack extends Model
     public static function updateAttack($attack){
         $attacks = Attack::all()->where('class_name','=',$attack->class_name)->
             where('redteam','=',$attack->redteam)->where('blueteam','=',$attack->blueteam);
-        foreach($attacks as $atk){
-            if($atk->success == null || $atk->detection_level < 2 || $atk->notified == false || $atk->isNews == false){
-                $att = $atk;
-            }
-        }
+        $att = Attack::find($attack->id);
         if($att == null) throw new AttackNotFoundException;
         $att->name = $attack->name;
         $att->class_name = $attack->class_name;

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -162,7 +162,7 @@ class Attack extends Model
         $attacks = Attack::all()->where('class_name','=',$attack->class_name)->
             where('redteam','=',$attack->redteam)->where('blueteam','=',$attack->blueteam);
         foreach($attacks as $atk){
-            if($atk->success == null || $atk->detection_level == 0 || $atk->notified == false || $atk->isNews == false){
+            if($atk->success == null || $atk->detection_level < 2 || $atk->notified == false || $atk->isNews == false){
                 $att = $atk;
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
         }
     },
     "autoload": {
+        "files": [
+            "app/Helpers/Helper.php"
+        ],
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",

--- a/resources/views/blueteam/attacks.blade.php
+++ b/resources/views/blueteam/attacks.blade.php
@@ -30,7 +30,7 @@
                         <td>{{App\Models\Team::find($attack->redteam)->name}}</td>
                         <td>{{$attack->success ? 'true' : 'false'}}</td>
                         <td>{{$attack->created_at->diffForHumans()}}</td>
-                        @if (!$attack->isNews && $attack->created_at->diffInDays() <= 3)
+                        @if (attack_broadcastable($attack))
                             <td>
                                 <form action="/blueteam/broadcast" method="post">
                                     @csrf

--- a/resources/views/blueteam/attacks.blade.php
+++ b/resources/views/blueteam/attacks.blade.php
@@ -16,7 +16,17 @@
             <tbody>
                 @foreach ($previousAttacks as $attack)
                     <tr>
-                        <td>{{$attack->getName()}}</td>
+                        <td>
+                            @if ($attack->detection_level < 2)
+                                <form action="/blueteam/analyzeAttack" method="post">
+                                    @csrf
+                                    <input type="hidden" name="attID" value={{$attack->id }}>
+                                    <input type="submit" name="analyze" value="Pay 500 To Analyze"/>
+                                </form>
+                            @else
+                                {{$attack->name}}
+                            @endif
+                        </td>
                         <td>{{App\Models\Team::find($attack->redteam)->name}}</td>
                         <td>{{$attack->success ? 'true' : 'false'}}</td>
                         <td>{{$attack->created_at->diffForHumans()}}</td>

--- a/resources/views/blueteam/home.blade.php
+++ b/resources/views/blueteam/home.blade.php
@@ -40,11 +40,14 @@
                 @else
                     The attack failed
                 @endif
+
+                @if (attack_broadcastable($attack))
                     <form action="/blueteam/broadcast" method="post">
                         @csrf
                         <input type="hidden" name="attID" value={{$attack->id}}>
                         <input type="submit" name="broadcast" value="Broadcast"/>
                     </form>
+                @endif
                 </p>
             @endforeach
             <form  action="/blueteam/clearNotifs" method="post">

--- a/tests/Feature/BlueTeamFeatureTest.php
+++ b/tests/Feature/BlueTeamFeatureTest.php
@@ -289,8 +289,7 @@ class BlueTeamFeatureTest extends TestCase
         $attack1->detection_level = 1;
         Attack::updateAttack($attack1);
 
-        $this->get('blueteam/home')->assertSeeInOrder(['?', 'Analyze']);
-        $this->get('blueteam/attacks')->assertSeeInOrder(['?', 'Analyze']);
+        $this->get('blueteam/attacks')->assertSee('Analyze');
     }
 
     public function testTeamCannotSeeAnalyzeButtonLvl2()
@@ -306,9 +305,6 @@ class BlueTeamFeatureTest extends TestCase
         $attack1->detection_level = 2;
         Attack::updateAttack($attack1);
 
-        $response = $this->get('blueteam/home');
-        $response->assertSee($attack1->name);
-        $response->assertDontSee('Analyze');
         $response = $this->get('blueteam/attacks');
         $response->assertSee($attack1->name);
         $response->assertDontSee('Analyze');


### PR DESCRIPTION
Tried using attack id to identify attack models when calling Attack::updateAttack(), hopefully makes the foreach loop and the boolean checks unneeded now. 

Added helper.php and a helper method. It holds the logic for if an attack can be broadcast. For now, that's if its not in the news already, and if its less than 3 days old. Instead of having the logic repeated twice in home and attacks page, I put it in its own method. 
May need to run composer dump-autoload for helper methods to work.