### PR TITLE
Add disable prereqs toggle on admin page

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -26,6 +26,9 @@ class AdminController extends Controller {
             case 'next-turn':
                 Game::endTurn();
                 break;
+            case 'toggle-prereqs':
+                Game::toggleDisablePrereqs();
+                break;
             default:
                 break;
         }

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -355,11 +355,14 @@ class Attack extends Model
             }
         }
         $this->calculated_difficulty = round($this->calculated_difficulty);
-        $unmet_prereqs = array_diff($this->prereqs, $have);
-        if ( count($unmet_prereqs) > 0 ) {
-            $this->possible = false;
-            $this->detection_level = 0;
-            $this->errormsg = "Unsatisfied prereqs for this attack";
+
+        if (!Game::prereqsDisabled()) {
+            $unmet_prereqs = array_diff($this->prereqs, $have);
+            if ( count($unmet_prereqs) > 0 ) {
+                $this->possible = false;
+                $this->detection_level = 0;
+                $this->errormsg = "Unsatisfied prereqs for this attack";
+            }
         }
         if ( $redteam->getEnergy() < $this->energy_cost ) {
             $this->possible = false;

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -61,4 +61,15 @@ class Game extends Model
             $redteam->setEnergy(1000);
         }
     }
+
+    public static function toggleDisablePrereqs(){
+        $game = Game::get();
+        $game->disable_prereqs = !$game->disable_prereqs;
+        $game->update();
+    } 
+
+    public static function prereqsDisabled(){
+        $game = Game::get();
+        return $game->disable_prereqs;
+    }
 }

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -70,6 +70,6 @@ class Game extends Model
 
     public static function prereqsDisabled(){
         $game = Game::get();
-        return $game->disable_prereqs;
+        return $game->disable_prereqs == 1;
     }
 }

--- a/database/migrations/2020_11_15_053007_create_games_table.php
+++ b/database/migrations/2020_11_15_053007_create_games_table.php
@@ -16,6 +16,7 @@ class CreateGamesTable extends Migration
         Schema::create('games', function (Blueprint $table) {
             $table->id();
             $table->integer('turn')->default(0);
+            $table->boolean('disable_prereqs')->default(false);
             $table->timestamps();
         });
     }

--- a/resources/views/admin/home.blade.php
+++ b/resources/views/admin/home.blade.php
@@ -5,4 +5,10 @@
     Turn number: {{ App\Models\Game::turnNumber() }}
     <form method="POST">@csrf<button type="submit" name="action" value="next-turn">Next Turn</button></form>
     <a href="/admin/playerRegistration"><button>Register Players</button></a> 
+    <form method="POST"> 
+        @csrf 
+        <input type="hidden" name="action" value="toggle-prereqs">
+        <input type="checkbox" onChange="this.form.submit()"@if(App\Models\Game::prereqsDisabled()) checked @endif>
+        Disable Attack Prereqs
+    </form>
 @endsection

--- a/tests/Unit/AttackTest.php
+++ b/tests/Unit/AttackTest.php
@@ -361,4 +361,20 @@ class AttackTest extends TestCase {
         $red->refresh();
         $this->assertEquals($attack->energy_cost, $red->balance);
     }
+
+    public function testDisablePrereqs(){
+        $red = Team::factory()->red()->create();
+        $blue = Team::factory()->create();
+        $attack1 = Attack::create('SQLInjection', $red->id, $blue->id);
+        $this->assertFalse(\App\Models\Game::prereqsDisabled());
+        $attack1->onPreAttack();
+        $this->assertFalse($attack1->possible);
+        $this->assertEquals("Unsatisfied prereqs for this attack", $attack1->errormsg);
+
+        \App\Models\Game::toggleDisablePrereqs();
+        $attack2 = Attack::create('SQLInjection', $red->id, $blue->id);
+        $attack2->onPreAttack();
+        $this->assertTrue($attack2->possible);
+        $this->assertNotEquals("Unsatisfied prereqs for this attack", $attack2->errormsg);
+    }
 }


### PR DESCRIPTION
Adds a toggle on admin home page that disables the prereqs check in Attack::onPreAttack(). Meant for testing purposes so it will be easier for us to do playtesting without having to fulfill attack prereqs