### PR TITLE
Refactor attack difficulty

### DIFF
--- a/app/Models/Assets/AdDeptAsset.php
+++ b/app/Models/Assets/AdDeptAsset.php
@@ -3,7 +3,6 @@
 namespace App\Models\Assets;
 
 use App\Models\Asset;
-use App\Models\Attack;
 
 class AdDeptAsset extends Asset 
 {
@@ -15,6 +14,7 @@ class AdDeptAsset extends Asset
     public $_buyable = 1;
     public $_purchase_cost = 300;
     public $_ownership_cost = -50;
+    public $_description = "Advertising Dept. gives you passive income each turn.";
 
     public function onPreAttack($attack)
     {

--- a/app/Models/Assets/BranchOfficeAsset.php
+++ b/app/Models/Assets/BranchOfficeAsset.php
@@ -18,7 +18,7 @@ class BranchOfficeAsset extends Asset
     public function onPreAttack($attack)
     {
         if (in_array('PhysicalAttack', $attack->tags)){
-            $attack->changeDifficulty(.15);
+            $attack->changeSuccessChance(-.15);
         }
     }
 }

--- a/app/Models/Assets/BranchOfficeAsset.php
+++ b/app/Models/Assets/BranchOfficeAsset.php
@@ -14,6 +14,7 @@ class BranchOfficeAsset extends Asset
     public $_buyable = 1;
     public $_purchase_cost = 2000;
     public $_ownership_cost = -2500;
+    public $_description = "Open a branch office that helps defend against physical attacks.";
 
     public function onPreAttack($attack)
     {

--- a/app/Models/Assets/CallCenterAsset.php
+++ b/app/Models/Assets/CallCenterAsset.php
@@ -18,10 +18,10 @@ class CallCenterAsset extends Asset
     public function onPreAttack($attack)
     {
         if (in_array('RequiresUserAction', $attack->tags)){
-            $attack->changeDifficulty(.2);
+            $attack->changeSuccessChance(-.2);
         }
         if (in_array('PhysicalAttack', $attack->tags)){
-            $attack->changeDifficulty(.1);
+            $attack->changeSuccessChance(-.1);
         }
     }
 }

--- a/app/Models/Assets/CallCenterAsset.php
+++ b/app/Models/Assets/CallCenterAsset.php
@@ -14,6 +14,7 @@ class CallCenterAsset extends Asset
     public $_buyable = 1;
     public $_purchase_cost = 2000;
     public $_ownership_cost = -1500;
+    public $_description = "Open a call center that helps defend against various types of attacks.";
 
     public function onPreAttack($attack)
     {

--- a/app/Models/Assets/CloudProviderAsset.php
+++ b/app/Models/Assets/CloudProviderAsset.php
@@ -17,11 +17,11 @@ class CloudProviderAsset extends Asset
 
     public function onPreAttack($attack)
     {
-        $attack->changeDetectionRisk(0.25);
-        $attack->changeAnalysisRisk(0.25);
-        $attack->changeAttributionRisk(0.25);
+        $attack->changeDetectionChance(0.25);
+        $attack->changeAnalysisChance(0.25);
+        $attack->changeAttributionChance(0.25);
         if (in_array('PhysicalAttack', $attack->tags)){
-            $attack->changeDifficulty(-.5);
+            $attack->changeSuccessChance(.5);
         }
     }
 }

--- a/app/Models/Assets/CloudProviderAsset.php
+++ b/app/Models/Assets/CloudProviderAsset.php
@@ -14,6 +14,7 @@ class CloudProviderAsset extends Asset
     public $_buyable = 1;
     public $_purchase_cost = 300;
     public $_ownership_cost = -200;
+    public $_description = "Use cloud services provider. Raises chance of detection, analysis, and attribution, but weak to physical attacks.";
 
     public function onPreAttack($attack)
     {

--- a/app/Models/Assets/EndpointProtectionAsset.php
+++ b/app/Models/Assets/EndpointProtectionAsset.php
@@ -18,9 +18,10 @@ class EndpointProtectionAsset extends Asset {
 
     function onPreAttack($attack) {
         if (in_array("AttackOnEndpoint", $attack->tags)) {
-            $attack->changeDifficulty(1);
-            $attack->changeDetectionRisk(1);
-            $attack->changeAnalysisRisk(1);
+            $attack->success_chance = 0;
+            Attack::updateAttack($attack);
+            $attack->changeDetectionChance(1);
+            $attack->changeAnalysisChance(1);
         }
     }
 }

--- a/app/Models/Assets/EndpointProtectionAsset.php
+++ b/app/Models/Assets/EndpointProtectionAsset.php
@@ -18,7 +18,7 @@ class EndpointProtectionAsset extends Asset {
 
     function onPreAttack($attack) {
         if (in_array("AttackOnEndpoint", $attack->tags)) {
-            $attack->success_chance = 0;
+            $attack->calculated_success_chance = 0;
             Attack::updateAttack($attack);
             $attack->changeDetectionChance(1);
             $attack->changeAnalysisChance(1);

--- a/app/Models/Assets/FirewallAsset.php
+++ b/app/Models/Assets/FirewallAsset.php
@@ -19,11 +19,11 @@ class FirewallAsset extends Asset {
 
     function onPreAttack($attack) {
         if (in_array("FirewallDefends", $attack->tags)) {
-            $attack->changeDifficulty(.2);
+            $attack->changeSuccessChance(-.2);
         }
         if (in_array('Internal', $attack->tags) || in_array('PrivilegedAccess', $attack->tags) || in_array('PwnedAccess', $attack->tags)){
-            $attack->changeDetectionRisk(.15);
-            $attack->changeAnalysisRisk(.15);
+            $attack->changeDetectionChance(.15);
+            $attack->changeAnalysisChance(.15);
         }
     }
 }

--- a/app/Models/Assets/FullDiskEncryptionAsset.php
+++ b/app/Models/Assets/FullDiskEncryptionAsset.php
@@ -18,12 +18,12 @@ class FullDiskEncryptionAsset extends Asset {
 
     function onPreAttack($attack) {
         if ($attack->class_name == "StolenLaptop") {
-            $attack->calculated_difficulty = 0.2;
+            $attack->calculated_success_chance = 0.2;
             $blueteam = Team::find($attack->blueteam);
             $invs = $blueteam->inventories();
             foreach($invs as $inv){
                 if($inv->asset_name == "StrongPassword"){
-                    $attack->calculated_difficulty = 0.03;
+                    $attack->calculated_success_chance = 0.03;
                 }
             }
             Attack::updateAttack($attack);

--- a/app/Models/Assets/FullDiskEncryptionAsset.php
+++ b/app/Models/Assets/FullDiskEncryptionAsset.php
@@ -18,12 +18,12 @@ class FullDiskEncryptionAsset extends Asset {
 
     function onPreAttack($attack) {
         if ($attack->class_name == "StolenLaptop") {
-            $attack->calculated_difficulty = 4;
+            $attack->calculated_difficulty = 0.2;
             $blueteam = Team::find($attack->blueteam);
             $invs = $blueteam->inventories();
             foreach($invs as $inv){
                 if($inv->asset_name == "StrongPassword"){
-                    $attack->calculated_difficulty = 4.85;
+                    $attack->calculated_difficulty = 0.03;
                 }
             }
             Attack::updateAttack($attack);

--- a/app/Models/Assets/HeightenedAwarenessAsset.php
+++ b/app/Models/Assets/HeightenedAwarenessAsset.php
@@ -22,8 +22,8 @@ class HeightenedAwarenessAsset extends Asset
     {
         $redteam = Team::find($attack->redteam);
         if($redteam->name == $attack->info){
-            $attack->changeDifficulty(.1);
-            $attack->changeDetectionRisk(.2);
+            $attack->changeSuccessChance(-.1);
+            $attack->changeDetectionChance(.2);
         }
     }
 }

--- a/app/Models/Assets/IDSAsset.php
+++ b/app/Models/Assets/IDSAsset.php
@@ -13,8 +13,11 @@ class IDSAsset extends Asset {
     public $_buyable = 1;
     public $_purchase_cost = 200;
     public $_ownership_cost = -200;
+    public $_description = "IDS costs money to maintain each turn, but helps detect and analyze attacks.";
 
     function onPreAttack($attack) {
-        
+        $attack->changeDetectionChance(0.25);
+        $attack->changeAnalysisChance(0.25);
+        $attack->changeAttributionChance(0.25);
     }
 }

--- a/app/Models/Assets/OnPremDataCenterAsset.php
+++ b/app/Models/Assets/OnPremDataCenterAsset.php
@@ -14,6 +14,7 @@ class OnPremDataCenterAsset extends Asset
     public $_buyable = 1;
     public $_purchase_cost = 10000;
     public $_ownership_cost = -1000;
+    public $_description = "Helps detect, analyze, and attribute attacks, but makes you slightly weaker to physical attacks.";
 
     public function onPreAttack($attack)
     {

--- a/app/Models/Assets/OnPremDataCenterAsset.php
+++ b/app/Models/Assets/OnPremDataCenterAsset.php
@@ -17,11 +17,11 @@ class OnPremDataCenterAsset extends Asset
 
     public function onPreAttack($attack)
     {
-        $attack->changeDetectionRisk(0.2);
-        $attack->changeAnalysisRisk(0.2);
-        $attack->changeAttributionRisk(0.2);
+        $attack->changeDetectionChance(0.2);
+        $attack->changeAnalysisChance(0.2);
+        $attack->changeAttributionChance(0.2);
         if (in_array('PhysicalAttack', $attack->tags)){
-            $attack->changeDifficulty(-.1);
+            $attack->changeSuccessChance(.1);
         }
     }
 }

--- a/app/Models/Assets/PRDeptAsset.php
+++ b/app/Models/Assets/PRDeptAsset.php
@@ -3,7 +3,6 @@
 namespace App\Models\Assets;
 
 use App\Models\Asset;
-use App\Models\Attack;
 
 class PRDeptAsset extends Asset 
 {
@@ -19,7 +18,7 @@ class PRDeptAsset extends Asset
     public function onPreAttack($attack)
     {
         if($attack->calculated_detection_risk > 3){
-            $attack->changeDifficulty(.1);
+            $attack->changeSuccessChance(-.1);
         }
     }
 }

--- a/app/Models/Assets/PRDeptAsset.php
+++ b/app/Models/Assets/PRDeptAsset.php
@@ -14,10 +14,11 @@ class PRDeptAsset extends Asset
     public $_buyable = 1;
     public $_purchase_cost = 200;
     public $_ownership_cost = 20;
+    public $_description = "Decreases chance of success for easy to detect attacks.";
 
     public function onPreAttack($attack)
     {
-        if($attack->calculated_detection_risk > 3){
+        if($attack->calculated_detection_chance > 0.6){
             $attack->changeSuccessChance(-.1);
         }
     }

--- a/app/Models/Assets/PhysicalAccessPolicyAsset.php
+++ b/app/Models/Assets/PhysicalAccessPolicyAsset.php
@@ -3,7 +3,6 @@
 namespace App\Models\Assets;
 
 use App\Models\Asset;
-use App\Models\Attack;
 
 class PhysicalAccessPolicyAsset extends Asset {
 
@@ -18,7 +17,7 @@ class PhysicalAccessPolicyAsset extends Asset {
 
     function onPreAttack($attack) {
         if (in_array("PhysicalAttack", $attack->tags)) {
-            $attack->changeDifficulty(.2);
+            $attack->changeSuccessChance(-.2);
         }
     }
 }

--- a/app/Models/Assets/RemoteAccessAsset.php
+++ b/app/Models/Assets/RemoteAccessAsset.php
@@ -14,6 +14,7 @@ class RemoteAccessAsset extends Asset {
     public $_purchase_cost = 100;
     public $_ownership_cost = -200;
     public $_percent_revenue_bonus = 10;
+    public $_description = "Gives passive income each turn, but 10% weaker to all attacks.";
 
     function onPreAttack($attack) {
         $attack->changeSuccessChance(.1);

--- a/app/Models/Assets/RemoteAccessAsset.php
+++ b/app/Models/Assets/RemoteAccessAsset.php
@@ -16,6 +16,6 @@ class RemoteAccessAsset extends Asset {
     public $_percent_revenue_bonus = 10;
 
     function onPreAttack($attack) {
-        $attack->changeDifficulty(-.1);
+        $attack->changeSuccessChance(.1);
     }
 }

--- a/app/Models/Assets/RemoteWorkPolicyAsset.php
+++ b/app/Models/Assets/RemoteWorkPolicyAsset.php
@@ -18,10 +18,10 @@ class RemoteWorkPolicyAsset extends Asset
     public function onPreAttack($attack)
     {
         if (in_array('RequiresUserAction', $attack->tags)){
-            $attack->changeDifficulty(.1);
+            $attack->changeSuccessChance(-.1);
         }
         if (in_array('PhysicalAttack', $attack->tags)){
-            $attack->changeDifficulty(-.1);
+            $attack->changeSuccessChance(.1);
         }
     }
 }

--- a/app/Models/Assets/RemoteWorkPolicyAsset.php
+++ b/app/Models/Assets/RemoteWorkPolicyAsset.php
@@ -14,6 +14,7 @@ class RemoteWorkPolicyAsset extends Asset
     public $_buyable = 1;
     public $_purchase_cost = 500;
     public $_ownership_cost = -200;
+    public $_description = "Gives passive income each turn, and resist RequiresUserAction attacks. 10% weaker to physical attacks.";
 
     public function onPreAttack($attack)
     {

--- a/app/Models/Assets/SecurityAnalystAsset.php
+++ b/app/Models/Assets/SecurityAnalystAsset.php
@@ -18,8 +18,8 @@ class SecurityAnalystAsset extends Asset
     public function onPreAttack($attack)
     {
         parent::onPreAttack($attack);
-        $attack->changeDifficulty(.1);
-        $attack->changeDetectionRisk(.3);
-        $attack->changeAnalysisRisk(.3);
+        $attack->changeSuccessChance(-.1);
+        $attack->changeDetectionChance(.3);
+        $attack->changeAnalysisChance(.3);
     }
 }

--- a/app/Models/Assets/SecurityMonitorAsset.php
+++ b/app/Models/Assets/SecurityMonitorAsset.php
@@ -19,7 +19,7 @@ class SecurityMonitorAsset extends Asset
     public function onPreAttack($attack)
     {
         if($attack->calculated_detection_risk > 3){
-            $attack->changeDetectionRisk(1);
+            $attack->changeDetectionChance(1);
         }
     }
 }

--- a/app/Models/Assets/SecurityMonitorAsset.php
+++ b/app/Models/Assets/SecurityMonitorAsset.php
@@ -3,7 +3,6 @@
 namespace App\Models\Assets;
 
 use App\Models\Asset;
-use App\Models\Attack;
 
 class SecurityMonitorAsset extends Asset 
 {
@@ -15,10 +14,11 @@ class SecurityMonitorAsset extends Asset
     public $_buyable = 1;
     public $_purchase_cost = 50;
     public $_ownership_cost = 10;
+    public $_description = "Guarantee an attack will be detected if detection chance was at least 50%.";
 
     public function onPreAttack($attack)
     {
-        if($attack->calculated_detection_risk > 3){
+        if($attack->calculated_detection_risk > 0.5){
             $attack->changeDetectionChance(1);
         }
     }

--- a/app/Models/Assets/StrongPasswordAsset.php
+++ b/app/Models/Assets/StrongPasswordAsset.php
@@ -19,7 +19,7 @@ class StrongPasswordAsset extends Asset {
 
     function onPreAttack($attack) {
         if ($attack->class_name == "PasswordGuessing") {
-            $attack->changeDifficulty(.5);
+            $attack->changeSuccessChance(-.5);
         }
     }
 }

--- a/app/Models/Assets/UserAwarenessAsset.php
+++ b/app/Models/Assets/UserAwarenessAsset.php
@@ -19,15 +19,15 @@ class UserAwarenessAsset extends Asset {
 
     function onPreAttack($attack) {
         if (in_array("TargetsEndpoints", $attack->tags)) {
-            $attack->changeDifficulty(.2);
+            $attack->changeSuccessChance(-.2);
         }
         if (in_array('SocialEngineering', $attack->tags)){
-            $attack->changeDifficulty(.3);
-            $attack-> changeDetectionRisk(.1);
-            $attack-> changeAnalysisRisk(.1);
+            $attack->changeSuccessChance(-.3);
+            $attack-> changeDetectionChance(.1);
+            $attack-> changeAnalysisChance(.1);
         }
         if( in_array('PhysicalAttack', $attack->tags) || $attack->class_name == "MaliciousInsider"){
-            $attack->changeDifficulty(.1);
+            $attack->changeSuccessChance(-.1);
         }
     }
 }

--- a/app/Models/Assets/VPNAsset.php
+++ b/app/Models/Assets/VPNAsset.php
@@ -20,7 +20,7 @@ class VPNAsset extends Asset
 
     public function onPreAttack($attack)
     {
-        if(in_array('SQLInjection', $attack->tags)) $attack->changeDetectionRisk(-.2);
-        if(in_array('ExternalNetworkProtocol', $attack->tags)) $attack->changeDetectionRisk(-.2);
+        if(in_array('SQLInjection', $attack->tags)) $attack->changeDetectionChance(-.2);
+        if(in_array('ExternalNetworkProtocol', $attack->tags)) $attack->changeDetectionChance(-.2);
     }
 }

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -17,7 +17,7 @@ class Attack extends Model
      *
      * @var array
      */
-    protected $fillable = [ 'name', 'class_name', 'energy_cost', 'difficulty','detection_risk', 'calculated_detection_risk', 'calculated_difficulty','success','detection_level','blueteam','redteam'];
+    protected $fillable = [ 'name', 'class_name', 'energy_cost', 'success_chance','detection_chance', 'calculated_detection_chance', 'calculated_success_chance','success','detection_level','blueteam','redteam'];
     protected $casts = [ 'tags' => 'array', 'prereqs' => 'array', 'payloads' => 'array']; // casts "json" database column to array and back
 
     public $_name    = "Abstract class - do not use";
@@ -26,27 +26,27 @@ class Attack extends Model
     public $_prereqs = [];
     public $_payload_tag = null;
     public $_payload_choice = null;
-    public $_initial_difficulty = 3;
-    public $_initial_detection_risk = 3;
+    public $_initial_success_chance = 3;
+    public $_initial_detection_chance = 3;
     public $_initial_detection = 0;
     public $_initial_energy_cost = 100;
     public $_possible = true;
     public $errormsg = "";
-    public $_initial_analysis_risk = null;
-    public $_initial_attribution_risk = null;
+    public $_initial_analysis_chance = null;
+    public $_initial_attribution_chance = null;
     public $_help_text = null;
 
     function __construct() {
         $this->name           = $this->_name;
         $this->class_name     = $this->_class_name;
-        $this->difficulty     = $this->_initial_difficulty;
-        $this->detection_risk = $this->_initial_detection_risk;
-        $this->analysis_risk  = $this->_initial_analysis_risk;
-        $this->attribution_risk = $this->_initial_attribution_risk;
-        $this->calculated_analysis_risk = $this->_initial_analysis_risk;
-        $this->calculated_attribution_risk = $this->_initial_attribution_risk;
-        $this->calculated_difficulty = $this->_initial_difficulty;
-        $this->calculated_detection_risk = $this->_initial_detection_risk;
+        $this->success_chance = $this->_initial_success_chance;
+        $this->detection_chance = $this->_initial_detection_chance;
+        $this->analysis_chance  = $this->_initial_analysis_chance;
+        $this->attribution_chance = $this->_initial_attribution_chance;
+        $this->calculated_analysis_chance = $this->_initial_analysis_chance;
+        $this->calculated_attribution_chance = $this->_initial_attribution_chance;
+        $this->calculated_success_chance = $this->_initial_success_chance;
+        $this->calculated_detection_chance = $this->_initial_detection_chance;
         $this->tags           = $this->_tags;
         $this->prereqs        = $this->_prereqs;
         $this->payload_tag    = $this->_payload_tag;
@@ -181,14 +181,14 @@ class Attack extends Model
         $this->prereqs = $attack->prereqs;
         $this->payload_tag = $attack->payload_tag;
         $this->payload_choice = $attack->payload_choice;
-        $this->difficulty = $attack->difficulty;
-        $this->detection_risk = $attack->detection_risk;
-        $this->analysis_risk = $attack->analysis_risk;
-        $this->attribution_risk = $attack->attribution_risk;
-        $this->calculated_detection_risk = $attack->calculated_detection_risk;
-        $this->calculated_difficulty = $attack->calculated_difficulty;
-        $this->calculated_analysis_risk = $attack->calculated_analysis_risk;
-        $this->calculated_attribution_risk = $attack->calculated_attribution_risk;
+        $this->success_chance = $attack->success_chance;
+        $this->detection_chance = $attack->detection_chance;
+        $this->analysis_chance = $attack->analysis_chance;
+        $this->attribution_chance = $attack->attribution_chance;
+        $this->calculated_detection_chance = $attack->calculated_detection_chance;
+        $this->calculated_success_chance = $attack->calculated_success_chance;
+        $this->calculated_analysis_chance = $attack->calculated_analysis_chance;
+        $this->calculated_attribution_chance = $attack->calculated_attribution_chance;
         $this->success = $attack->success;
         $this->detection_level = $attack->detection_level;
         $this->notified = $attack->notified;
@@ -241,18 +241,18 @@ class Attack extends Model
 
     public function calculateDetected() {
         $rand = rand(0, 500)/100;
-        if ($rand > $this->calculated_detection_risk) {
+        if ($rand > $this->calculated_detection_chance) {
             $this->detection_level = 0;
         }
         else {
             $this->detection_level = 1;
             $blueteam = Team::find($this->blueteam);
             $rand = rand(0, 500)/100;
-            if ($rand < $this->calculated_analysis_risk){
+            if ($rand < $this->calculated_analysis_chance){
                 $this->detection_level = 2;
                 $this->checkAnalysisBonus();
                 $rand = rand(0, 500)/100;
-                if($rand < $this->calculated_attribution_risk){
+                if($rand < $this->calculated_attribution_chance){
                     $this->detection_level = 3;
                 }
             }
@@ -284,30 +284,30 @@ class Attack extends Model
     }
     
     public function changeDifficulty($val){
-        $this->calculated_difficulty += $val * $this->difficulty;
-        if($this->calculated_difficulty > 5) $this->calculated_difficulty = 5;
-        if($this->calculated_difficulty < 1) $this->calculated_difficulty = 1;
+        $this->calculated_success_chance += $val * $this->success_chance;
+        if($this->calculated_success_chance > 5) $this->calculated_success_chance = 5;
+        if($this->calculated_success_chance < 1) $this->calculated_success_chance = 1;
         Attack::updateAttack($this);
     }
 
     public function changeDetectionRisk($val){
-        $this->calculated_detection_risk += $val * $this->detection_risk;
-        if($this->calculated_detection_risk > 5) $this->calculated_detection_risk = 5;
-        if($this->calculated_detection_risk < 0) $this->calculated_detection_risk = 0;
+        $this->calculated_detection_chance += $val * $this->detection_chance;
+        if($this->calculated_detection_chance > 5) $this->calculated_detection_chance = 5;
+        if($this->calculated_detection_chance < 0) $this->calculated_detection_chance = 0;
         Attack::updateAttack($this);
     }
 
     public function changeAnalysisRisk($val){
-        $this->calculated_analysis_risk += $val * $this->analysis_risk;
-        if($this->calculated_analysis_risk > 5) $this->calculated_analysis_risk = 5;
-        if($this->calculated_analysis_risk < 0) $this->calculated_analysis_risk = 0;
+        $this->calculated_analysis_chance += $val * $this->analysis_chance;
+        if($this->calculated_analysis_chance > 5) $this->calculated_analysis_chance = 5;
+        if($this->calculated_analysis_chance < 0) $this->calculated_analysis_chance = 0;
         Attack::updateAttack($this);
     }
 
     public function changeAttributionRisk($val){
-        $this->calculated_detection_risk += $val * $this->detection_risk;
-        if($this->calculated_detection_risk > 5) $this->calculated_detection_risk = 5;
-        if($this->calculated_detection_risk < 0) $this->calculated_detection_risk = 0;
+        $this->calculated_detection_chance += $val * $this->detection_chance;
+        if($this->calculated_detection_chance > 5) $this->calculated_detection_chance = 5;
+        if($this->calculated_detection_chance < 0) $this->calculated_detection_chance = 0;
         Attack::updateAttack($this);
     }
 
@@ -369,7 +369,7 @@ class Attack extends Model
         foreach ($bonuses as $bonus){
             $this->applyBonus($bonus);
         }
-        $this->calculated_difficulty = round($this->calculated_difficulty);
+        $this->calculated_success_chance = round($this->calculated_success_chance);
         Attack::updateAttack($this);
         return $this;
     }

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -26,8 +26,8 @@ class Attack extends Model
     public $_prereqs = [];
     public $_payload_tag = null;
     public $_payload_choice = null;
-    public $_initial_success_chance = 3;
-    public $_initial_detection_chance = 3;
+    public $_initial_success_chance = 0.5;
+    public $_initial_detection_chance = 0.5;
     public $_initial_detection = 0;
     public $_initial_energy_cost = 100;
     public $_possible = true;

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -240,17 +240,17 @@ class Attack extends Model
     }
 
     public function calculateDetected() {
-        $rand = rand(0, 100)/100;
+        $rand = rand(0, 99)/100;
         if ($rand >= $this->calculated_detection_chance) {
             $this->detection_level = 0;
         }
         else {
             $this->detection_level = 1;
-            $rand = rand(0, 100)/100;
+            $rand = rand(0, 99)/100;
             if ($rand < $this->calculated_analysis_chance){
                 $this->detection_level = 2;
                 $this->checkAnalysisBonus();
-                $rand = rand(0, 100)/100;
+                $rand = rand(0, 99)/100;
                 if($rand < $this->calculated_attribution_chance){
                     $this->detection_level = 3;
                 }
@@ -305,7 +305,7 @@ class Attack extends Model
     private function calculateNewProbability($initial, $val){
         $result = $initial + ($initial*$val);
         if ($result > 1) { return 1; }
-        elseif ($result < 0.2) { return 0.2; }
+        elseif ($result < 0) { return 0; }
         else { return $result; }
     }
 
@@ -332,7 +332,11 @@ class Attack extends Model
      * Converts success_chance to difficulty for minigames. 5 = impossible, 0 = always succeeds
      */
     public function getDifficulty(){
-        return round(5*(1-$this->calculated_success_chance));
+        $difficulty = round(5*(1-$this->calculated_success_chance));
+        if($difficulty < 1){
+            $difficulty = 1;
+        }
+        return $difficulty;
     }
 
     public function onPreAttack() {

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -330,6 +330,13 @@ class Attack extends Model
         return Payload::getByTag($this->payload_tag);
     }
 
+    /**
+     * Converts success_chance to difficulty for minigames. 5 = impossible, 0 = always succeeds
+     */
+    public function getDifficulty(){
+        return 5*(1-$this->calculated_success_chance);
+    }
+
     public function onPreAttack() {
         $blueteam = Team::find($this->blueteam);
         $redteam  = Team::find($this->redteam);

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -332,7 +332,7 @@ class Attack extends Model
      * Converts success_chance to difficulty for minigames. 5 = impossible, 0 = always succeeds
      */
     public function getDifficulty(){
-        return 5*(1-$this->calculated_success_chance);
+        return round(5*(1-$this->calculated_success_chance));
     }
 
     public function onPreAttack() {

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -415,10 +415,10 @@ class Attack extends Model
 
     private function applyBonus($bonus){
         if(in_array("DifficultyDeduction", $bonus->tags)){
-            $this->changeDifficulty(-1 * 0.01 * $bonus->percentDiffDeducted);
+            $this->changeSuccessChance(-1 * 0.01 * $bonus->percentDiffDeducted);
         }
         if(in_array("DetectionDeduction", $bonus->tags)){
-            $this->changeDetectionRisk(-1 * 0.01 * $bonus->percentDetDeducted);
+            $this->changeDetectionChance(-1 * 0.01 * $bonus->percentDetDeducted);
         }
     }
 }

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -247,11 +247,11 @@ class Attack extends Model
         else {
             $this->detection_level = 1;
             $rand = rand(0, 100)/100;
-            if ($rand <= $this->calculated_analysis_chance){
+            if ($rand < $this->calculated_analysis_chance){
                 $this->detection_level = 2;
                 $this->checkAnalysisBonus();
                 $rand = rand(0, 100)/100;
-                if($rand <= $this->calculated_attribution_chance){
+                if($rand < $this->calculated_attribution_chance){
                     $this->detection_level = 3;
                 }
             }

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -241,17 +241,17 @@ class Attack extends Model
 
     public function calculateDetected() {
         $rand = rand(0, 100)/100;
-        if ($rand > $this->calculated_detection_chance) {
+        if ($rand >= $this->calculated_detection_chance) {
             $this->detection_level = 0;
         }
         else {
             $this->detection_level = 1;
             $rand = rand(0, 100)/100;
-            if ($rand < $this->calculated_analysis_chance){
+            if ($rand <= $this->calculated_analysis_chance){
                 $this->detection_level = 2;
                 $this->checkAnalysisBonus();
                 $rand = rand(0, 100)/100;
-                if($rand < $this->calculated_attribution_chance){
+                if($rand <= $this->calculated_attribution_chance){
                     $this->detection_level = 3;
                 }
             }

--- a/app/Models/Attack.php
+++ b/app/Models/Attack.php
@@ -282,22 +282,22 @@ class Attack extends Model
         return $bonuses;
     }
     
-    public function changeDifficulty($val){
+    public function changeSuccessChance($val){
         $this->calculated_success_chance = $this->calculateNewProbability($this->calculated_success_chance, $val);
         Attack::updateAttack($this);
     }
 
-    public function changeDetectionRisk($val){
+    public function changeDetectionChance($val){
         $this->calculated_detection_chance = $this->calculateNewProbability($this->calculated_detection_chance, $val);
         Attack::updateAttack($this);
     }
 
-    public function changeAnalysisRisk($val){
+    public function changeAnalysisChance($val){
         $this->calculated_analysis_chance = $this->calculateNewProbability($this->calculated_analysis_chance, $val);
         Attack::updateAttack($this);
     }
 
-    public function changeAttributionRisk($val){
+    public function changeAttributionChance($val){
         $this->calculated_attribution_chance = $this->calculateNewProbability($this->calculated_attribution_chance, $val);
         Attack::updateAttack($this);
     }

--- a/app/Models/Attacks/ActionsOnObjectiveAttack.php
+++ b/app/Models/Attacks/ActionsOnObjectiveAttack.php
@@ -11,10 +11,10 @@ class ActionsOnObjectiveAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['PwnedAccess'];
     public $_payload_choice         = 'StealRevenue';
-    public $_initial_difficulty     = 0.5;
-    public $_initial_detection_risk = 4;
-    public $_initial_analysis_risk  = 1;
-    public $_initial_attribution_risk = 1.5;
+    public $_initial_success_chance = 0.5;
+    public $_initial_detection_chance = 4;
+    public $_initial_analysis_chance  = 1;
+    public $_initial_attribution_chance = 1.5;
     public $_initial_energy_cost    = 10;
     public $_help_text              = "Leverage full access to steal money directly.";
 

--- a/app/Models/Attacks/ActionsOnObjectiveAttack.php
+++ b/app/Models/Attacks/ActionsOnObjectiveAttack.php
@@ -11,10 +11,10 @@ class ActionsOnObjectiveAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['PwnedAccess'];
     public $_payload_choice         = 'StealRevenue';
-    public $_initial_success_chance = 0.5;
-    public $_initial_detection_chance = 4;
-    public $_initial_analysis_chance  = 1;
-    public $_initial_attribution_chance = 1.5;
+    public $_initial_success_chance = 0.90;
+    public $_initial_detection_chance = 0.8;
+    public $_initial_analysis_chance  = 0.2;
+    public $_initial_attribution_chance = 0.3;
     public $_initial_energy_cost    = 10;
     public $_help_text              = "Leverage full access to steal money directly.";
 

--- a/app/Models/Attacks/BackdoorBasicAttack.php
+++ b/app/Models/Attacks/BackdoorBasicAttack.php
@@ -11,8 +11,8 @@ class BackdoorBasicAttack extends Attack {
     public $_class_name             = "BackdoorBasic";
     public $_tags                   = ['Internal'];
     public $_prereqs                = [];
-    public $_initial_difficulty     = 2;
-    public $_initial_detection_risk = 2;
+    public $_initial_success_chance  = 2;
+    public $_initial_detection_chance = 2;
     public $_initial_energy_cost    = 100;
     public $_help_text              = "Use existing access tokens to secure more, ensuring you will maintain access to the company.";
 

--- a/app/Models/Attacks/BackdoorBasicAttack.php
+++ b/app/Models/Attacks/BackdoorBasicAttack.php
@@ -11,8 +11,8 @@ class BackdoorBasicAttack extends Attack {
     public $_class_name             = "BackdoorBasic";
     public $_tags                   = ['Internal'];
     public $_prereqs                = [];
-    public $_initial_success_chance  = 2;
-    public $_initial_detection_chance = 2;
+    public $_initial_success_chance  = 0.6;
+    public $_initial_detection_chance = 0.4;
     public $_initial_energy_cost    = 100;
     public $_help_text              = "Use existing access tokens to secure more, ensuring you will maintain access to the company.";
 

--- a/app/Models/Attacks/BackdoorPrivilegedAttack.php
+++ b/app/Models/Attacks/BackdoorPrivilegedAttack.php
@@ -11,8 +11,8 @@ class BackdoorPrivilegedAttack extends Attack {
     public $_class_name             = "BackdoorPrivileged";
     public $_tags                   = ['Internal','PrivilegedAccess'];
     public $_prereqs                = [];
-    public $_initial_success_chance = 2;
-    public $_initial_detection_chance = 2;
+    public $_initial_success_chance = 0.6;
+    public $_initial_detection_chance = 0.4;
     public $_initial_energy_cost    = 150;
     public $_help_text              = "Use existing access tokens to secure more, ensuring you will maintain access to the company.";
 

--- a/app/Models/Attacks/BackdoorPrivilegedAttack.php
+++ b/app/Models/Attacks/BackdoorPrivilegedAttack.php
@@ -11,8 +11,8 @@ class BackdoorPrivilegedAttack extends Attack {
     public $_class_name             = "BackdoorPrivileged";
     public $_tags                   = ['Internal','PrivilegedAccess'];
     public $_prereqs                = [];
-    public $_initial_difficulty     = 2;
-    public $_initial_detection_risk = 2;
+    public $_initial_success_chance = 2;
+    public $_initial_detection_chance = 2;
     public $_initial_energy_cost    = 150;
     public $_help_text              = "Use existing access tokens to secure more, ensuring you will maintain access to the company.";
 

--- a/app/Models/Attacks/BackdoorPwnedAttack.php
+++ b/app/Models/Attacks/BackdoorPwnedAttack.php
@@ -11,8 +11,8 @@ class BackdoorPwnedAttack extends Attack {
     public $_class_name             = "BackdoorPwned";
     public $_tags                   = ['Internal','PwnedAccess'];
     public $_prereqs                = [];
-    public $_initial_success_chance = 2;
-    public $_initial_detection_chance = 2;
+    public $_initial_success_chance = 0.6;
+    public $_initial_detection_chance = 0.4;
     public $_initial_energy_cost    = 400;
     public $_help_text              = "Use existing access tokens to secure more, ensuring you will maintain access to the company.";
 

--- a/app/Models/Attacks/BackdoorPwnedAttack.php
+++ b/app/Models/Attacks/BackdoorPwnedAttack.php
@@ -11,8 +11,8 @@ class BackdoorPwnedAttack extends Attack {
     public $_class_name             = "BackdoorPwned";
     public $_tags                   = ['Internal','PwnedAccess'];
     public $_prereqs                = [];
-    public $_initial_difficulty     = 2;
-    public $_initial_detection_risk = 2;
+    public $_initial_success_chance = 2;
+    public $_initial_detection_chance = 2;
     public $_initial_energy_cost    = 400;
     public $_help_text              = "Use existing access tokens to secure more, ensuring you will maintain access to the company.";
 

--- a/app/Models/Attacks/DDosAttack.php
+++ b/app/Models/Attacks/DDosAttack.php
@@ -11,10 +11,10 @@ class DDosAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['BotNet'];
     public $_payload_choice           = "Dos";
-    public $_initial_difficulty     = 1.25;
-    public $_initial_detection_risk = 5;
-    public $_initial_analysis_risk  = 4.5;
-    public $_initial_attribution_risk = 1;
+    public $_initial_success_chance = 1.25;
+    public $_initial_detection_chance = 5;
+    public $_initial_analysis_chance  = 4.5;
+    public $_initial_attribution_chance = 1;
     public $_initial_energy_cost    = 400;
     public $_help_text              = "Like DoS, but involving hundreds of servers. Hard to recover from.";
 

--- a/app/Models/Attacks/DDosAttack.php
+++ b/app/Models/Attacks/DDosAttack.php
@@ -11,10 +11,10 @@ class DDosAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['BotNet'];
     public $_payload_choice           = "Dos";
-    public $_initial_success_chance = 1.25;
-    public $_initial_detection_chance = 5;
-    public $_initial_analysis_chance  = 4.5;
-    public $_initial_attribution_chance = 1;
+    public $_initial_success_chance = 0.75;
+    public $_initial_detection_chance = 1;
+    public $_initial_analysis_chance  = 0.9;
+    public $_initial_attribution_chance = 0.2;
     public $_initial_energy_cost    = 400;
     public $_help_text              = "Like DoS, but involving hundreds of servers. Hard to recover from.";
 

--- a/app/Models/Attacks/DataCenterIntrusionAttack.php
+++ b/app/Models/Attacks/DataCenterIntrusionAttack.php
@@ -10,11 +10,10 @@ class DataCenterIntrusionAttack extends Attack {
     public $_class_name             = "DataCenterIntrusion";
     public $_tags                   = ['PhysicalAttack'];
     public $_prereqs                = ['PhysicalAccess'];
-    public $_payload_choice           = "Dos";
-    public $_initial_difficulty     = 3.25; //35% chance of success
-    public $_initial_detection_risk = 3.5; //30%
-    public $_initial_analysis_risk  = 1.5; //70%
-    public $_initial_attribution_risk = 3.75; //25%
+    public $_initial_success_chance = 3.25; //35% chance of success
+    public $_initial_detection_chance = 3.5; //30%
+    public $_initial_analysis_chance  = 1.5; //70%
+    public $_initial_attribution_chance = 3.75; //25%
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Perform a physical attack on the target's data center. Requires physical access.";
 

--- a/app/Models/Attacks/DataCenterIntrusionAttack.php
+++ b/app/Models/Attacks/DataCenterIntrusionAttack.php
@@ -10,10 +10,10 @@ class DataCenterIntrusionAttack extends Attack {
     public $_class_name             = "DataCenterIntrusion";
     public $_tags                   = ['PhysicalAttack'];
     public $_prereqs                = ['PhysicalAccess'];
-    public $_initial_success_chance = 3.25; //35% chance of success
-    public $_initial_detection_chance = 3.5; //30%
-    public $_initial_analysis_chance  = 1.5; //70%
-    public $_initial_attribution_chance = 3.75; //25%
+    public $_initial_success_chance = 0.35;
+    public $_initial_detection_chance = 0.3;
+    public $_initial_analysis_chance  = 0.70;
+    public $_initial_attribution_chance = 0.25;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Perform a physical attack on the target's data center. Requires physical access.";
 

--- a/app/Models/Attacks/DosAttack.php
+++ b/app/Models/Attacks/DosAttack.php
@@ -11,10 +11,10 @@ class DosAttack extends Attack {
     public $_tags                   = ['FirewallDefends'];
     public $_prereqs                = [];
     public $_payload_choice           = "Dos";
-    public $_initial_success_chance = 1.25;
-    public $_initial_detection_chance = 5;
-    public $_initial_analysis_chance = 4.5;
-    public $_initial_attribution_chance = 1;
+    public $_initial_success_chance = 0.75;
+    public $_initial_detection_chance = 1;
+    public $_initial_analysis_chance = 0.9;
+    public $_initial_attribution_chance = 0.2;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Take the company offline by passing expensive or excessive traffic.";
 

--- a/app/Models/Attacks/DosAttack.php
+++ b/app/Models/Attacks/DosAttack.php
@@ -11,10 +11,10 @@ class DosAttack extends Attack {
     public $_tags                   = ['FirewallDefends'];
     public $_prereqs                = [];
     public $_payload_choice           = "Dos";
-    public $_initial_difficulty     = 1.25;
-    public $_initial_detection_risk = 5;
-    public $_initial_analysis_risk  = 4.5;
-    public $_initial_attribution_risk = 1;
+    public $_initial_success_chance = 1.25;
+    public $_initial_detection_chance = 5;
+    public $_initial_analysis_chance = 4.5;
+    public $_initial_attribution_chance = 1;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Take the company offline by passing expensive or excessive traffic.";
 

--- a/app/Models/Attacks/DriveByAttack.php
+++ b/app/Models/Attacks/DriveByAttack.php
@@ -11,10 +11,9 @@ class DriveByAttack extends Attack {
     public $_tags                   = ['CodeExecution','TargetsEndpoints'];
     public $_prereqs                = ['MaliciousWebsite'];
     public $_payload_tag           = 'EndpointExecutable';
-    public $_initial_success_chance = 2.5;
-    public $_initial_detection_chance = 1.5;
-    public $_initial_analysis_chance = 2;
-    public $_initial_attribution_chance = 2.5;
+    public $_initial_detection_chance = 0.3;
+    public $_initial_analysis_chance = 0.4;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Redirect employees to malicious website. Compromise browser or workstation.";
 

--- a/app/Models/Attacks/DriveByAttack.php
+++ b/app/Models/Attacks/DriveByAttack.php
@@ -11,10 +11,10 @@ class DriveByAttack extends Attack {
     public $_tags                   = ['CodeExecution','TargetsEndpoints'];
     public $_prereqs                = ['MaliciousWebsite'];
     public $_payload_tag           = 'EndpointExecutable';
-    public $_initial_difficulty     = 2.5;
-    public $_initial_detection_risk = 1.5;
-    public $_initial_analysis_risk  = 2;
-    public $_initial_attribution_risk = 2.5;
+    public $_initial_success_chance = 2.5;
+    public $_initial_detection_chance = 1.5;
+    public $_initial_analysis_chance = 2;
+    public $_initial_attribution_chance = 2.5;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Redirect employees to malicious website. Compromise browser or workstation.";
 

--- a/app/Models/Attacks/EavesdroppingAttack.php
+++ b/app/Models/Attacks/EavesdroppingAttack.php
@@ -11,10 +11,10 @@ class EavesdroppingAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['Internal', 'PrivilegedAccess'];
     public $_payload_choice         = 'Eavesdropping';
-    public $_initial_difficulty     = 1.5;
-    public $_initial_detection_risk = 1;
-    public $_initial_analysis_risk  = 3.5;
-    public $_initial_attribution_risk = 1;
+    public $_initial_success_chance = 1.5;
+    public $_initial_detection_chance = 1;
+    public $_initial_analysis_chance  = 3.5;
+    public $_initial_attribution_chance = 1;
     public $_initial_energy_cost    = 400;
     public $_help_text              = "Spy on network traffic for credentials or info.";
 

--- a/app/Models/Attacks/EavesdroppingAttack.php
+++ b/app/Models/Attacks/EavesdroppingAttack.php
@@ -11,10 +11,10 @@ class EavesdroppingAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['Internal', 'PrivilegedAccess'];
     public $_payload_choice         = 'Eavesdropping';
-    public $_initial_success_chance = 1.5;
-    public $_initial_detection_chance = 1;
-    public $_initial_analysis_chance  = 3.5;
-    public $_initial_attribution_chance = 1;
+    public $_initial_success_chance = 0.7;
+    public $_initial_detection_chance = 0.2;
+    public $_initial_analysis_chance  = 0.7;
+    public $_initial_attribution_chance = 0.2;
     public $_initial_energy_cost    = 400;
     public $_help_text              = "Spy on network traffic for credentials or info.";
 

--- a/app/Models/Attacks/FoundMediaAttack.php
+++ b/app/Models/Attacks/FoundMediaAttack.php
@@ -11,10 +11,10 @@ class FoundMediaAttack extends Attack {
     public $_tags                   = ['RequiresUserAction','TargetsEndpoints','CodeExecution'];
     public $_prereqs                = [];
     public $_payload_tag            = 'EndpointExecutable';
-    public $_initial_difficulty     = 3.5;
-    public $_initial_detection_risk = 2;
-    public $_initial_analysis_risk  = 2;
-    public $_initial_attribution_risk = 2.5;
+    public $_initial_success_chance = 3.5;
+    public $_initial_detection_chance = 2;
+    public $_initial_analysis_chance = 2;
+    public $_initial_attribution_chance = 2.5;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "An employee \"finds\" a flash drive and inserts it.";
 

--- a/app/Models/Attacks/FoundMediaAttack.php
+++ b/app/Models/Attacks/FoundMediaAttack.php
@@ -11,10 +11,10 @@ class FoundMediaAttack extends Attack {
     public $_tags                   = ['RequiresUserAction','TargetsEndpoints','CodeExecution'];
     public $_prereqs                = [];
     public $_payload_tag            = 'EndpointExecutable';
-    public $_initial_success_chance = 3.5;
-    public $_initial_detection_chance = 2;
-    public $_initial_analysis_chance = 2;
-    public $_initial_attribution_chance = 2.5;
+    public $_initial_success_chance = 0.3;
+    public $_initial_detection_chance = 0.4;
+    public $_initial_analysis_chance = 0.4;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "An employee \"finds\" a flash drive and inserts it.";
 

--- a/app/Models/Attacks/FuzzingAttack.php
+++ b/app/Models/Attacks/FuzzingAttack.php
@@ -11,10 +11,10 @@ class FuzzingAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['ExternalNetworkService'];
     public $_payload_choice         = 'Fuzzing';
-    public $_initial_difficulty     = 3.5;
-    public $_initial_detection_risk = 3;
-    public $_initial_analysis_risk  = 1;
-    public $_initial_attribution_risk = 0.5;
+    public $_initial_success_chance = 3.5;
+    public $_initial_detection_chance = 3;
+    public $_initial_analysis_chance = 1;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Exploit a service using randomized data.";
 

--- a/app/Models/Attacks/FuzzingAttack.php
+++ b/app/Models/Attacks/FuzzingAttack.php
@@ -11,10 +11,10 @@ class FuzzingAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['ExternalNetworkService'];
     public $_payload_choice         = 'Fuzzing';
-    public $_initial_success_chance = 3.5;
-    public $_initial_detection_chance = 3;
-    public $_initial_analysis_chance = 1;
-    public $_initial_attribution_chance = 0.5;
+    public $_initial_success_chance = 0.3;
+    public $_initial_detection_chance = 0.6;
+    public $_initial_analysis_chance = 0.2;
+    public $_initial_attribution_chance = 0.1;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Exploit a service using randomized data.";
 

--- a/app/Models/Attacks/ImplantedHwOfficeAttack.php
+++ b/app/Models/Attacks/ImplantedHwOfficeAttack.php
@@ -11,10 +11,10 @@ class ImplantedHwOfficeAttack extends Attack {
     public $_tags                   = ['HardwareAttack','PhysicalAttack'];
     public $_prereqs                = ['PhysicalAccess'];
     public $_payload_tag           = 'OfficeHW';
-    public $_initial_success_chance = 4.5;
-    public $_initial_detection_chance = 1.25;
-    public $_initial_analysis_chance = 2;
-    public $_initial_attribution_chance = 1.5;
+    public $_initial_success_chance = 0.1;
+    public $_initial_detection_chance = 0.25;
+    public $_initial_analysis_chance = 0.4;
+    public $_initial_attribution_chance = 0.3;
     public $_initial_energy_cost    = 300;
     public $_help_text              = "Plant a piece of hardware in the office.";
 

--- a/app/Models/Attacks/ImplantedHwOfficeAttack.php
+++ b/app/Models/Attacks/ImplantedHwOfficeAttack.php
@@ -11,10 +11,10 @@ class ImplantedHwOfficeAttack extends Attack {
     public $_tags                   = ['HardwareAttack','PhysicalAttack'];
     public $_prereqs                = ['PhysicalAccess'];
     public $_payload_tag           = 'OfficeHW';
-    public $_initial_difficulty     = 4.5;
-    public $_initial_detection_risk = 1.25;
-    public $_initial_analysis_risk  = 2;
-    public $_initial_attribution_risk = 1.5;
+    public $_initial_success_chance = 4.5;
+    public $_initial_detection_chance = 1.25;
+    public $_initial_analysis_chance = 2;
+    public $_initial_attribution_chance = 1.5;
     public $_initial_energy_cost    = 300;
     public $_help_text              = "Plant a piece of hardware in the office.";
 

--- a/app/Models/Attacks/ImplantedHwServerAttack.php
+++ b/app/Models/Attacks/ImplantedHwServerAttack.php
@@ -11,10 +11,10 @@ class ImplantedHwServerAttack extends Attack {
     public $_tags                   = ['HardwareAttack','PhysicalAttack'];
     public $_prereqs                = ['DataCenterAccess'];
     public $_payload_tag           = 'ServerHW';
-    public $_initial_success_chance = 4.5;
-    public $_initial_detection_chance = 2;
-    public $_initial_analysis_chance  = 2;
-    public $_initial_attribution_chance = 2;
+    public $_initial_success_chance = 0.1;
+    public $_initial_detection_chance = 0.4;
+    public $_initial_analysis_chance  = 0.4;
+    public $_initial_attribution_chance = 0.4;
     public $_initial_energy_cost    = 500;
     public $_help_text              = "Plant a piece of hardware in the datacenter.";
 

--- a/app/Models/Attacks/ImplantedHwServerAttack.php
+++ b/app/Models/Attacks/ImplantedHwServerAttack.php
@@ -11,10 +11,10 @@ class ImplantedHwServerAttack extends Attack {
     public $_tags                   = ['HardwareAttack','PhysicalAttack'];
     public $_prereqs                = ['DataCenterAccess'];
     public $_payload_tag           = 'ServerHW';
-    public $_initial_difficulty     = 4.5;
-    public $_initial_detection_risk = 2;
-    public $_initial_analysis_risk  = 2;
-    public $_initial_attribution_risk = 2;
+    public $_initial_success_chance = 4.5;
+    public $_initial_detection_chance = 2;
+    public $_initial_analysis_chance  = 2;
+    public $_initial_attribution_chance = 2;
     public $_initial_energy_cost    = 500;
     public $_help_text              = "Plant a piece of hardware in the datacenter.";
 

--- a/app/Models/Attacks/KnownExploitAttack.php
+++ b/app/Models/Attacks/KnownExploitAttack.php
@@ -11,10 +11,10 @@ class KnownExploitAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['ExternalNetworkService'];
     public $_payload_tag         = 'Executable';
-    public $_initial_difficulty     = 2;
-    public $_initial_detection_risk = 2;
-    public $_initial_analysis_risk  = 4;
-    public $_initial_attribution_risk = 1.5;
+    public $_initial_success_chance = 2;
+    public $_initial_detection_chance = 2;
+    public $_initial_analysis_chance  = 4;
+    public $_initial_attribution_chance = 1.5;
     public $_initial_energy_cost    = 100;
     public $_help_text              = "Find a known, unpatched vulnerability.";
 

--- a/app/Models/Attacks/KnownExploitAttack.php
+++ b/app/Models/Attacks/KnownExploitAttack.php
@@ -11,10 +11,10 @@ class KnownExploitAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['ExternalNetworkService'];
     public $_payload_tag         = 'Executable';
-    public $_initial_success_chance = 2;
-    public $_initial_detection_chance = 2;
-    public $_initial_analysis_chance  = 4;
-    public $_initial_attribution_chance = 1.5;
+    public $_initial_success_chance = 0.6;
+    public $_initial_detection_chance = 0.4;
+    public $_initial_analysis_chance  = 0.8;
+    public $_initial_attribution_chance = 0.3;
     public $_initial_energy_cost    = 100;
     public $_help_text              = "Find a known, unpatched vulnerability.";
 

--- a/app/Models/Attacks/MaliciousInsiderAttack.php
+++ b/app/Models/Attacks/MaliciousInsiderAttack.php
@@ -11,10 +11,10 @@ class MaliciousInsiderAttack extends Attack {
     public $_tags                   = ['PhysicalAttack'];
     public $_prereqs                = [];
     public $_payload_choice         = 'MaliciousInsider';
-    public $_initial_success_chance = 2;
-    public $_initial_detection_chance = 2.5;
-    public $_initial_analysis_chance  = 5;
-    public $_initial_attribution_chance = 4;
+    public $_initial_success_chance = 0.6;
+    public $_initial_detection_chance = 0.6;
+    public $_initial_analysis_chance  = 1;
+    public $_initial_attribution_chance = 0.2;
     public $_initial_energy_cost    = 1000;
     public $_help_text              = "Get hired as an employee.";
 

--- a/app/Models/Attacks/MaliciousInsiderAttack.php
+++ b/app/Models/Attacks/MaliciousInsiderAttack.php
@@ -11,10 +11,10 @@ class MaliciousInsiderAttack extends Attack {
     public $_tags                   = ['PhysicalAttack'];
     public $_prereqs                = [];
     public $_payload_choice         = 'MaliciousInsider';
-    public $_initial_difficulty     = 2;
-    public $_initial_detection_risk = 2.5;
-    public $_initial_analysis_risk  = 5;
-    public $_initial_attribution_risk = 4;
+    public $_initial_success_chance = 2;
+    public $_initial_detection_chance = 2.5;
+    public $_initial_analysis_chance  = 5;
+    public $_initial_attribution_chance = 4;
     public $_initial_energy_cost    = 1000;
     public $_help_text              = "Get hired as an employee.";
 

--- a/app/Models/Attacks/MalvertiseAttack.php
+++ b/app/Models/Attacks/MalvertiseAttack.php
@@ -11,8 +11,8 @@ class MalvertiseAttack extends Attack {
     public $_class_name             = "Malvertise";
     public $_tags                   = [];
     public $_prereqs                = ['AdDept'];
-    public $_initial_success_chance = 3;
-    public $_initial_detection_chance = 4;
+    public $_initial_success_chance = 0.4;
+    public $_initial_detection_chance = 0.8;
     public $_initial_energy_cost    = 100;
 
     public $learn_page              = true;

--- a/app/Models/Attacks/MalvertiseAttack.php
+++ b/app/Models/Attacks/MalvertiseAttack.php
@@ -11,8 +11,8 @@ class MalvertiseAttack extends Attack {
     public $_class_name             = "Malvertise";
     public $_tags                   = [];
     public $_prereqs                = ['AdDept'];
-    public $_initial_difficulty     = 3;
-    public $_initial_detection_risk = 4;
+    public $_initial_success_chance = 3;
+    public $_initial_detection_chance = 4;
     public $_initial_energy_cost    = 100;
 
     public $learn_page              = true;

--- a/app/Models/Attacks/MitMAttack.php
+++ b/app/Models/Attacks/MitMAttack.php
@@ -11,10 +11,10 @@ class MitMAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = [];
     public $_payload_choice           = "BasicAccess";
-    public $_initial_success_chance = 3.5;
-    public $_initial_detection_chance = 1;
-    public $_initial_analysis_chance  = 3.5;
-    public $_initial_attribution_chance = 0.5;
+    public $_initial_success_chance = 0.3;
+    public $_initial_detection_chance = 0.2;
+    public $_initial_analysis_chance  = 0.7;
+    public $_initial_attribution_chance = 0.1;
     public $_initial_energy_cost    = 50;
     public $_help_text              = "Be a middleman for traffic between employees and the company.";
 

--- a/app/Models/Attacks/MitMAttack.php
+++ b/app/Models/Attacks/MitMAttack.php
@@ -11,10 +11,10 @@ class MitMAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = [];
     public $_payload_choice           = "BasicAccess";
-    public $_initial_difficulty     = 3.5;
-    public $_initial_detection_risk = 1;
-    public $_initial_analysis_risk  = 3.5;
-    public $_initial_attribution_risk = 0.5;
+    public $_initial_success_chance = 3.5;
+    public $_initial_detection_chance = 1;
+    public $_initial_analysis_chance  = 3.5;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 50;
     public $_help_text              = "Be a middleman for traffic between employees and the company.";
 

--- a/app/Models/Attacks/NewExploitAttack.php
+++ b/app/Models/Attacks/NewExploitAttack.php
@@ -11,10 +11,10 @@ class NewExploitAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['ExternalNetworkService'];
     public $_payload_tag            = 'Executable';
-    public $_initial_difficulty     = 4;
-    public $_initial_detection_risk = 2.5;
-    public $_initial_analysis_risk  = 1;
-    public $_initial_attribution_risk = 2.5;
+    public $_initial_success_chance  = 4;
+    public $_initial_detection_chance = 2.5;
+    public $_initial_analysis_chance  = 1;
+    public $_initial_attribution_chance = 2.5;
     public $_initial_energy_cost    = 800;
     public $_help_text              = "Find a new unknown vulnerability in an app.";
 

--- a/app/Models/Attacks/NewExploitAttack.php
+++ b/app/Models/Attacks/NewExploitAttack.php
@@ -11,10 +11,10 @@ class NewExploitAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['ExternalNetworkService'];
     public $_payload_tag            = 'Executable';
-    public $_initial_success_chance  = 4;
-    public $_initial_detection_chance = 2.5;
-    public $_initial_analysis_chance  = 1;
-    public $_initial_attribution_chance = 2.5;
+    public $_initial_success_chance  = 0.2;
+    public $_initial_detection_chance = 0.5;
+    public $_initial_analysis_chance  = 0.2;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 800;
     public $_help_text              = "Find a new unknown vulnerability in an app.";
 

--- a/app/Models/Attacks/OsintAttack.php
+++ b/app/Models/Attacks/OsintAttack.php
@@ -11,7 +11,7 @@ class OsintAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = [];
     public $_payload_choice           = "SecInfo";
-    public $_initial_success_chance = 4;
+    public $_initial_success_chance = 0.8;
     public $_initial_detection_chance = 0;
     public $_initial_analysis_chance  = 0;
     public $_initial_attribution_chance = 0;

--- a/app/Models/Attacks/OsintAttack.php
+++ b/app/Models/Attacks/OsintAttack.php
@@ -11,10 +11,10 @@ class OsintAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = [];
     public $_payload_choice           = "SecInfo";
-    public $_initial_difficulty     = 4;
-    public $_initial_detection_risk = 0;
-    public $_initial_analysis_risk  = 0;
-    public $_initial_attribution_risk = 0;
+    public $_initial_success_chance = 4;
+    public $_initial_detection_chance = 0;
+    public $_initial_analysis_chance  = 0;
+    public $_initial_attribution_chance = 0;
     public $_initial_energy_cost    = 30;
     public $_help_text              = "Recon from public information.";
 

--- a/app/Models/Attacks/PasswordGuessingAttack.php
+++ b/app/Models/Attacks/PasswordGuessingAttack.php
@@ -11,10 +11,10 @@ class PasswordGuessingAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = [];
     public $_payload_choice           = "BasicAccess";
-    public $_initial_success_chance = 3.5;
-    public $_initial_detection_chance = 3.5;
-    public $_initial_analysis_chance  = 4.5;
-    public $_initial_attribution_chance = 0.5;
+    public $_initial_success_chance = 0.30;
+    public $_initial_detection_chance = 0.7;
+    public $_initial_analysis_chance  = 0.9;
+    public $_initial_attribution_chance = 0.1;
     public $_initial_energy_cost    = 300;
     public $_help_text              = "Gain access through brute force and dictionary attacks.";
 

--- a/app/Models/Attacks/PasswordGuessingAttack.php
+++ b/app/Models/Attacks/PasswordGuessingAttack.php
@@ -11,10 +11,10 @@ class PasswordGuessingAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = [];
     public $_payload_choice           = "BasicAccess";
-    public $_initial_difficulty     = 3.5;
-    public $_initial_detection_risk = 3.5;
-    public $_initial_analysis_risk  = 4.5;
-    public $_initial_attribution_risk = 0.5;
+    public $_initial_success_chance = 3.5;
+    public $_initial_detection_chance = 3.5;
+    public $_initial_analysis_chance  = 4.5;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 300;
     public $_help_text              = "Gain access through brute force and dictionary attacks.";
 

--- a/app/Models/Attacks/PhishingAttachmentAttack.php
+++ b/app/Models/Attacks/PhishingAttachmentAttack.php
@@ -11,10 +11,10 @@ class PhishingAttachmentAttack extends Attack {
     public $_tags                   = ['RequiresUserAction','TargetsEndpoints','CodeExecution'];
     public $_prereqs                = [];
     public $_payload_tag            = 'EndpointExecutable';
-    public $_initial_difficulty     = 3.75;
-    public $_initial_detection_chance = 2;
-    public $_initial_analysis_chance  = 3;
-    public $_initial_attribution_chance = 1.5;
+    public $_initial_difficulty     = 0.25;
+    public $_initial_detection_chance = 0.4;
+    public $_initial_analysis_chance  = 0.6;
+    public $_initial_attribution_chance = 0.3;
     public $_initial_energy_cost    = 50;
     public $_help_text              = "Get an employee to open a malicious attachment.";
 

--- a/app/Models/Attacks/PhishingAttachmentAttack.php
+++ b/app/Models/Attacks/PhishingAttachmentAttack.php
@@ -12,9 +12,9 @@ class PhishingAttachmentAttack extends Attack {
     public $_prereqs                = [];
     public $_payload_tag            = 'EndpointExecutable';
     public $_initial_difficulty     = 3.75;
-    public $_initial_detection_risk = 2;
-    public $_initial_analysis_risk  = 3;
-    public $_initial_attribution_risk = 1.5;
+    public $_initial_detection_chance = 2;
+    public $_initial_analysis_chance  = 3;
+    public $_initial_attribution_chance = 1.5;
     public $_initial_energy_cost    = 50;
     public $_help_text              = "Get an employee to open a malicious attachment.";
 

--- a/app/Models/Attacks/PhishingCredentialsAttack.php
+++ b/app/Models/Attacks/PhishingCredentialsAttack.php
@@ -11,10 +11,10 @@ class PhishingCredentialsAttack extends Attack {
     public $_tags                   = ['RequiresUserAction'];
     public $_prereqs                = ['FakeLoginSite'];
     public $_payload_choice           = 'BasicAccess';
-    public $_initial_difficulty     = 3.5;
-    public $_initial_detection_risk = 0.5;
-    public $_initial_analysis_risk  = 4;
-    public $_initial_attribution_risk = 1;
+    public $_initial_success_chance = 3.5;
+    public $_initial_detection_chance = 0.5;
+    public $_initial_analysis_chance  = 4;
+    public $_initial_attribution_chance = 1;
     public $_initial_energy_cost    = 100;
     public $_help_text              = "Get employee to use a fake login page.";
 

--- a/app/Models/Attacks/PhishingCredentialsAttack.php
+++ b/app/Models/Attacks/PhishingCredentialsAttack.php
@@ -11,10 +11,10 @@ class PhishingCredentialsAttack extends Attack {
     public $_tags                   = ['RequiresUserAction'];
     public $_prereqs                = ['FakeLoginSite'];
     public $_payload_choice           = 'BasicAccess';
-    public $_initial_success_chance = 3.5;
-    public $_initial_detection_chance = 0.5;
-    public $_initial_analysis_chance  = 4;
-    public $_initial_attribution_chance = 1;
+    public $_initial_success_chance = 0.3;
+    public $_initial_detection_chance = 0.1;
+    public $_initial_analysis_chance  = 0.8;
+    public $_initial_attribution_chance = 0.2;
     public $_initial_energy_cost    = 100;
     public $_help_text              = "Get employee to use a fake login page.";
 

--- a/app/Models/Attacks/PhishingLinkAttack.php
+++ b/app/Models/Attacks/PhishingLinkAttack.php
@@ -11,10 +11,10 @@ class PhishingLinkAttack extends Attack {
     public $_tags                   = ['RequiresUserAction','TargetsEndpoints','CodeExecution'];
     public $_prereqs                = ['MaliciousWebsite'];
     public $_payload_tag          = 'EndpointExecutable';
-    public $_initial_difficulty     = 3.5;
-    public $_initial_detection_risk = 1;
-    public $_initial_analysis_risk  = 2.5;
-    public $_initial_attribution_risk = 2.5;
+    public $_initial_success_chance = 3.5;
+    public $_initial_detection_chance = 1;
+    public $_initial_analysis_chance  = 2.5;
+    public $_initial_attribution_chance = 2.5;
     public $_initial_energy_cost    = 150;
     public $_help_text              = "Get an employee to click on a malicious link.";
 

--- a/app/Models/Attacks/PhishingLinkAttack.php
+++ b/app/Models/Attacks/PhishingLinkAttack.php
@@ -11,10 +11,10 @@ class PhishingLinkAttack extends Attack {
     public $_tags                   = ['RequiresUserAction','TargetsEndpoints','CodeExecution'];
     public $_prereqs                = ['MaliciousWebsite'];
     public $_payload_tag          = 'EndpointExecutable';
-    public $_initial_success_chance = 3.5;
-    public $_initial_detection_chance = 1;
-    public $_initial_analysis_chance  = 2.5;
-    public $_initial_attribution_chance = 2.5;
+    public $_initial_success_chance = 0.3;
+    public $_initial_detection_chance = 0.2;
+    public $_initial_analysis_chance  = 0.5;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 150;
     public $_help_text              = "Get an employee to click on a malicious link.";
 

--- a/app/Models/Attacks/SQLInjectionAttack.php
+++ b/app/Models/Attacks/SQLInjectionAttack.php
@@ -11,10 +11,10 @@ class SQLInjectionAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['SQLDatabase'];
     public $_payload_tag            = 'DBAttack';
-    public $_initial_success_chance = 2;
-    public $_initial_detection_chance = 3;
-    public $_initial_analysis_chance = 3;
-    public $_initial_attribution_chance = 1.5;
+    public $_initial_success_chance = 0.6;
+    public $_initial_detection_chance = 0.6;
+    public $_initial_analysis_chance = 0.6;
+    public $_initial_attribution_chance = 0.3;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Send commands to the company's database.";
 

--- a/app/Models/Attacks/SQLInjectionAttack.php
+++ b/app/Models/Attacks/SQLInjectionAttack.php
@@ -11,10 +11,10 @@ class SQLInjectionAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['SQLDatabase'];
     public $_payload_tag            = 'DBAttack';
-    public $_initial_difficulty     = 2;
-    public $_initial_detection_risk = 3;
-    public $_initial_analysis_risk = 3;
-    public $_initial_attribution_risk = 1.5;
+    public $_initial_success_chance = 2;
+    public $_initial_detection_chance = 3;
+    public $_initial_analysis_chance = 3;
+    public $_initial_attribution_chance = 1.5;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Send commands to the company's database.";
 

--- a/app/Models/Attacks/ScanAttack.php
+++ b/app/Models/Attacks/ScanAttack.php
@@ -11,10 +11,10 @@ class ScanAttack extends Attack {
     public $_tags                   = ['FirewallDefends'];
     public $_prereqs                = [];
     public $_payload_choice           = "SecInfo";
-    public $_initial_difficulty     = 0;
-    public $_initial_detection_risk = 2.5;
-    public $_initial_analysis_risk  = 4.5;
-    public $_initial_attribution_risk = 0.5;
+    public $_initial_success_chance = 0;
+    public $_initial_detection_chance = 2.5;
+    public $_initial_analysis_chance  = 4.5;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 20;
     public $_help_text              = "Find information on services and hosts reachable from outside.";
 

--- a/app/Models/Attacks/ScanAttack.php
+++ b/app/Models/Attacks/ScanAttack.php
@@ -11,10 +11,10 @@ class ScanAttack extends Attack {
     public $_tags                   = ['FirewallDefends'];
     public $_prereqs                = [];
     public $_payload_choice           = "SecInfo";
-    public $_initial_success_chance = 0;
-    public $_initial_detection_chance = 2.5;
-    public $_initial_analysis_chance  = 4.5;
-    public $_initial_attribution_chance = 0.5;
+    public $_initial_success_chance = 1;
+    public $_initial_detection_chance = 0.5;
+    public $_initial_analysis_chance  = 0.9;
+    public $_initial_attribution_chance = 0.1;
     public $_initial_energy_cost    = 20;
     public $_help_text              = "Find information on services and hosts reachable from outside.";
 

--- a/app/Models/Attacks/ShoulderSurfingAttack.php
+++ b/app/Models/Attacks/ShoulderSurfingAttack.php
@@ -11,10 +11,10 @@ class ShoulderSurfingAttack extends Attack {
     public $_tags                   = ['PhysicalAttack'];
     public $_prereqs                = [];
     public $_payload_choice           = "BasicAccess";
-    public $_initial_success_chance = 3;
-    public $_initial_detection_chance = 1;
-    public $_initial_analysis_chance  = 2.5;
-    public $_initial_attribution_chance = 0.5;
+    public $_initial_success_chance = 0.4;
+    public $_initial_detection_chance = 0.2;
+    public $_initial_analysis_chance  = 0.5;
+    public $_initial_attribution_chance = 0.1;
     public $_initial_energy_cost    = 30;
     public $_help_text              = "Obtain password via physically watching/recording someone type it in.";
 

--- a/app/Models/Attacks/ShoulderSurfingAttack.php
+++ b/app/Models/Attacks/ShoulderSurfingAttack.php
@@ -11,10 +11,10 @@ class ShoulderSurfingAttack extends Attack {
     public $_tags                   = ['PhysicalAttack'];
     public $_prereqs                = [];
     public $_payload_choice           = "BasicAccess";
-    public $_initial_difficulty     = 3;
-    public $_initial_detection_risk = 1;
-    public $_initial_analysis_risk  = 2.5;
-    public $_initial_attribution_risk = 0.5;
+    public $_initial_success_chance = 3;
+    public $_initial_detection_chance = 1;
+    public $_initial_analysis_chance  = 2.5;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 30;
     public $_help_text              = "Obtain password via physically watching/recording someone type it in.";
 

--- a/app/Models/Attacks/StolenLaptopAttack.php
+++ b/app/Models/Attacks/StolenLaptopAttack.php
@@ -11,8 +11,8 @@ class StolenLaptopAttack extends Attack {
     public $_tags                   = ['PhysicalAttack','AttackOnEndpoint'];
     public $_prereqs                = [];
     public $_payload_choice           = "StolenLaptop";
-    public $_initial_success_chance = 0;
-    public $_initial_detection_chance = 4.5;
+    public $_initial_success_chance = 0.25;
+    public $_initial_detection_chance = 0.9;
     public $_initial_analysis_chance  = 0;
     public $_initial_attribution_chance = 0;
     public $_initial_energy_cost    = 500;

--- a/app/Models/Attacks/StolenLaptopAttack.php
+++ b/app/Models/Attacks/StolenLaptopAttack.php
@@ -11,10 +11,10 @@ class StolenLaptopAttack extends Attack {
     public $_tags                   = ['PhysicalAttack','AttackOnEndpoint'];
     public $_prereqs                = [];
     public $_payload_choice           = "StolenLaptop";
-    public $_initial_difficulty     = 0;
-    public $_initial_detection_risk = 4.5;
-    public $_initial_analysis_risk  = 0;
-    public $_initial_attribution_risk = 0;
+    public $_initial_success_chance = 0;
+    public $_initial_detection_chance = 4.5;
+    public $_initial_analysis_chance  = 0;
+    public $_initial_attribution_chance = 0;
     public $_initial_energy_cost    = 500;
     public $_help_text              = "Steal an employees laptop and harvest it for credentials/access.";
 

--- a/app/Models/Attacks/SupplyChainDevAttack.php
+++ b/app/Models/Attacks/SupplyChainDevAttack.php
@@ -11,10 +11,10 @@ class SupplyChainDevAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['SecInfo'];
     public $_payload_tag           = 'ServerExecutable';
-    public $_initial_success_chance = 4.5;
-    public $_initial_detection_chance = 2.5;
-    public $_initial_analysis_chance  = 3.5;
-    public $_initial_attribution_chance = 3;
+    public $_initial_success_chance = 0.1;
+    public $_initial_detection_chance = 0.5;
+    public $_initial_analysis_chance  = 0.75;
+    public $_initial_attribution_chance = 0.6;
     public $_initial_energy_cost    = 500;
     public $_help_text              = "Compromise a tool or dependency used by the company's software developement team.";
 

--- a/app/Models/Attacks/SupplyChainDevAttack.php
+++ b/app/Models/Attacks/SupplyChainDevAttack.php
@@ -11,10 +11,10 @@ class SupplyChainDevAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['SecInfo'];
     public $_payload_tag           = 'ServerExecutable';
-    public $_initial_difficulty     = 4.5;
-    public $_initial_detection_risk = 2.5;
-    public $_initial_analysis_risk  = 3.5;
-    public $_initial_attribution_risk = 3;
+    public $_initial_success_chance = 4.5;
+    public $_initial_detection_chance = 2.5;
+    public $_initial_analysis_chance  = 3.5;
+    public $_initial_attribution_chance = 3;
     public $_initial_energy_cost    = 500;
     public $_help_text              = "Compromise a tool or dependency used by the company's software developement team.";
 

--- a/app/Models/Attacks/SupplyChainHwAttack.php
+++ b/app/Models/Attacks/SupplyChainHwAttack.php
@@ -11,10 +11,10 @@ class SupplyChainHwAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['SecInfo'];
     public $_payload_tag           = 'ServerExecutable';
-    public $_initial_success_chance = 4.5;
-    public $_initial_detection_chance = 1;
-    public $_initial_analysis_chance  = 1;
-    public $_initial_attribution_chance = 1;
+    public $_initial_success_chance = 0.1;
+    public $_initial_detection_chance = 0.2;
+    public $_initial_analysis_chance  = 0.2;
+    public $_initial_attribution_chance = 0.2;
     public $_initial_energy_cost    = 1000;
     public $_help_text              = "Compromise the hardware a company buys at the factory or during shipping.";
 

--- a/app/Models/Attacks/SupplyChainHwAttack.php
+++ b/app/Models/Attacks/SupplyChainHwAttack.php
@@ -11,10 +11,10 @@ class SupplyChainHwAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['SecInfo'];
     public $_payload_tag           = 'ServerExecutable';
-    public $_initial_difficulty     = 4.5;
-    public $_initial_detection_risk = 1;
-    public $_initial_analysis_risk  = 1;
-    public $_initial_attribution_risk = 1;
+    public $_initial_success_chance = 4.5;
+    public $_initial_detection_chance = 1;
+    public $_initial_analysis_chance  = 1;
+    public $_initial_attribution_chance = 1;
     public $_initial_energy_cost    = 1000;
     public $_help_text              = "Compromise the hardware a company buys at the factory or during shipping.";
 

--- a/app/Models/Attacks/SupplyChainSwAttack.php
+++ b/app/Models/Attacks/SupplyChainSwAttack.php
@@ -11,10 +11,10 @@ class SupplyChainSwAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['SecInfo'];
     public $_payload_tag           = 'ServerExecutable';
-    public $_initial_success_chance = 4.5;
-    public $_initial_detection_chance = 1.5;
-    public $_initial_analysis_chance  = 3;
-    public $_initial_attribution_chance = 2.5;
+    public $_initial_success_chance = 0.1;
+    public $_initial_detection_chance = 0.3;
+    public $_initial_analysis_chance  = 0.6;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 750;
     public $_help_text              = "Compromise off the shelf software used by a company.";
 

--- a/app/Models/Attacks/SupplyChainSwAttack.php
+++ b/app/Models/Attacks/SupplyChainSwAttack.php
@@ -11,10 +11,10 @@ class SupplyChainSwAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['SecInfo'];
     public $_payload_tag           = 'ServerExecutable';
-    public $_initial_difficulty     = 4.5;
-    public $_initial_detection_risk = 1.5;
-    public $_initial_analysis_risk  = 3;
-    public $_initial_attribution_risk = 2.5;
+    public $_initial_success_chance = 4.5;
+    public $_initial_detection_chance = 1.5;
+    public $_initial_analysis_chance  = 3;
+    public $_initial_attribution_chance = 2.5;
     public $_initial_energy_cost    = 750;
     public $_help_text              = "Compromise off the shelf software used by a company.";
 

--- a/app/Models/Attacks/SynFloodAttack.php
+++ b/app/Models/Attacks/SynFloodAttack.php
@@ -10,8 +10,8 @@ class SynFloodAttack extends Attack {
     public $_class_name             = "SynFlood";
     public $_tags                   = ['ExternalNetworkProtocol', 'DenialOfService'];
     public $_prereqs                = [];
-    public $_initial_success_chance = 2;
-    public $_initial_detection_chance = 5;
+    public $_initial_success_chance = 0.6;
+    public $_initial_detection_chance = 1;
     public $_initial_energy_cost    = 100;
 
     public $learn_page              = true;

--- a/app/Models/Attacks/SynFloodAttack.php
+++ b/app/Models/Attacks/SynFloodAttack.php
@@ -10,8 +10,8 @@ class SynFloodAttack extends Attack {
     public $_class_name             = "SynFlood";
     public $_tags                   = ['ExternalNetworkProtocol', 'DenialOfService'];
     public $_prereqs                = [];
-    public $_initial_difficulty     = 2;
-    public $_initial_detection_risk = 5;
+    public $_initial_success_chance = 2;
+    public $_initial_detection_chance = 5;
     public $_initial_energy_cost    = 100;
 
     public $learn_page              = true;

--- a/app/Models/Attacks/WirelessNetworkAttack.php
+++ b/app/Models/Attacks/WirelessNetworkAttack.php
@@ -11,10 +11,10 @@ class WirelessNetworkAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = [];
     public $_payload_choice           = "BasicAccess";
-    public $_initial_difficulty     = 2;
-    public $_initial_detection_risk = 1;
-    public $_initial_analysis_risk  = 3;
-    public $_initial_attribution_risk = 0.5;
+    public $_initial_success_chance = 2;
+    public $_initial_detection_chance = 1;
+    public $_initial_analysis_chance = 3;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 400;
     public $_help_text              = "Access the company's wireless network.";
 

--- a/app/Models/Attacks/WirelessNetworkAttack.php
+++ b/app/Models/Attacks/WirelessNetworkAttack.php
@@ -11,10 +11,10 @@ class WirelessNetworkAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = [];
     public $_payload_choice           = "BasicAccess";
-    public $_initial_success_chance = 2;
-    public $_initial_detection_chance = 1;
-    public $_initial_analysis_chance = 3;
-    public $_initial_attribution_chance = 0.5;
+    public $_initial_success_chance = 0.6;
+    public $_initial_detection_chance = 0.2;
+    public $_initial_analysis_chance = 0.6;
+    public $_initial_attribution_chance = 0.1;
     public $_initial_energy_cost    = 400;
     public $_help_text              = "Access the company's wireless network.";
 

--- a/app/Models/Attacks/XssAttack.php
+++ b/app/Models/Attacks/XssAttack.php
@@ -11,10 +11,10 @@ class XssAttack extends Attack {
     public $_tags                   = ['TargetsCustomers'];
     public $_prereqs                = ['MaliciousWebsite','BlueWebsite'];
     public $_payload_choice           = "Xss";
-    public $_initial_success_chance = 3.5;
-    public $_initial_detection_chance = 1;
-    public $_initial_analysis_chance = 2.5;
-    public $_initial_attribution_chance = 2.5;
+    public $_initial_success_chance = 0.3;
+    public $_initial_detection_chance = 0.2;
+    public $_initial_analysis_chance = 0.5;
+    public $_initial_attribution_chance = 0.5;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Redirect customers to your own website.";
 

--- a/app/Models/Attacks/XssAttack.php
+++ b/app/Models/Attacks/XssAttack.php
@@ -11,10 +11,10 @@ class XssAttack extends Attack {
     public $_tags                   = ['TargetsCustomers'];
     public $_prereqs                = ['MaliciousWebsite','BlueWebsite'];
     public $_payload_choice           = "Xss";
-    public $_initial_difficulty     = 3.5;
-    public $_initial_detection_risk = 1;
-    public $_initial_analysis_risk  = 2.5;
-    public $_initial_attribution_risk = 2.5;
+    public $_initial_success_chance = 3.5;
+    public $_initial_detection_chance = 1;
+    public $_initial_analysis_chance = 2.5;
+    public $_initial_attribution_chance = 2.5;
     public $_initial_energy_cost    = 200;
     public $_help_text              = "Redirect customers to your own website.";
 

--- a/app/Models/Attacks/ZeroDayExploitAttack.php
+++ b/app/Models/Attacks/ZeroDayExploitAttack.php
@@ -11,10 +11,10 @@ class ZeroDayExploitAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['ZeroDay'];
     public $_payload_tag            = 'Executable';
-    public $_initial_difficulty     = 0.5;
-    public $_initial_detection_risk = 1;
-    public $_initial_analysis_risk  = 1;
-    public $_initial_attribution_risk = 1.5;
+    public $_initial_success_chance = 0.5;
+    public $_initial_detection_chance = 1;
+    public $_initial_analysis_chance = 1;
+    public $_initial_attribution_chance = 1.5;
     public $_initial_energy_cost    = 100;
     public $_help_text              = "Use a vulnerability they haven't seen before.";
 

--- a/app/Models/Attacks/ZeroDayExploitAttack.php
+++ b/app/Models/Attacks/ZeroDayExploitAttack.php
@@ -11,10 +11,10 @@ class ZeroDayExploitAttack extends Attack {
     public $_tags                   = [];
     public $_prereqs                = ['ZeroDay'];
     public $_payload_tag            = 'Executable';
-    public $_initial_success_chance = 0.5;
-    public $_initial_detection_chance = 1;
-    public $_initial_analysis_chance = 1;
-    public $_initial_attribution_chance = 1.5;
+    public $_initial_success_chance = 0.9;
+    public $_initial_detection_chance = 0.2;
+    public $_initial_analysis_chance = 0.2;
+    public $_initial_attribution_chance = 0.3;
     public $_initial_energy_cost    = 100;
     public $_help_text              = "Use a vulnerability they haven't seen before.";
 

--- a/app/Models/Payload.php
+++ b/app/Models/Payload.php
@@ -37,7 +37,7 @@ class Payload //extends Model
     public function onPreAttack($attack){
         //Handle changes to attack success rate here
         if ($this->percentIncreasedSuccess != 0){
-            $difficultyChange = -1 * $this->percentIncreasedSuccess;
+            $difficultyChange = $this->percentIncreasedSuccess/100;
             $attack->changeDifficulty($difficultyChange);
         }
     }

--- a/app/Models/Payload.php
+++ b/app/Models/Payload.php
@@ -37,8 +37,7 @@ class Payload //extends Model
     public function onPreAttack($attack){
         //Handle changes to attack success rate here
         if ($this->percentIncreasedSuccess != 0){
-            $difficultyChange = $this->percentIncreasedSuccess/100;
-            $attack->changeDifficulty($difficultyChange);
+            $attack->changeSuccessChance($this->percentIncreasedSuccess/100);
         }
     }
     

--- a/database/migrations/2020_11_04_041646_create_attacks_table.php
+++ b/database/migrations/2020_11_04_041646_create_attacks_table.php
@@ -23,14 +23,14 @@ class CreateAttacksTable extends Migration
             $table->text('payload_choice')->nullable();
             $table->foreignId('blueteam')->constrained('teams')->onDelete('cascade');
             $table->foreignId('redteam')->constrained('teams')->onDelete('cascade');
-            $table->decimal('difficulty'); // 0.0 - 5.0, 0 always succeeds, 5 always fails.
-            $table->decimal('detection_risk');    // 0.0 - 5.0, 0 is never detected, 5 is always detected
-            $table->decimal('analysis_risk')->nullable();
-            $table->decimal('attribution_risk')->nullable();
-            $table->decimal('calculated_difficulty');
-            $table->decimal('calculated_detection_risk');
-            $table->decimal('calculated_analysis_risk')->nullable();
-            $table->decimal('calculated_attribution_risk')->nullable();
+            $table->decimal('success_chance'); // 0.0 - 5.0, 0 always succeeds, 5 always fails.
+            $table->decimal('detection_chance');    // 0.0 - 5.0, 0 is never detected, 5 is always detected
+            $table->decimal('analysis_chance')->nullable();
+            $table->decimal('attribution_chance')->nullable();
+            $table->decimal('calculated_success_chance');
+            $table->decimal('calculated_detection_chance');
+            $table->decimal('calculated_analysis_chance')->nullable();
+            $table->decimal('calculated_attribution_chance')->nullable();
             $table->boolean('possible')->default('true');
             $table->boolean('success')->nullable();
             $table->integer('detection_level')->nullable(); //0 = unseen, 1 = detected, 2 = analyzed by sec. analyst, etc.

--- a/resources/views/minigame/malvertise.blade.php
+++ b/resources/views/minigame/malvertise.blade.php
@@ -8,7 +8,7 @@
     <?php function random($attack){
         $randInt = rand(1,4);
         $val = 0;
-        if($randInt > $attack->difficulty - 1){
+        if($randInt > $attack->getDifficulty() - 1){
             $val = 1;
         }
         return $val;

--- a/resources/views/minigame/sqlinjection.blade.php
+++ b/resources/views/minigame/sqlinjection.blade.php
@@ -9,7 +9,7 @@
     <h2>Attempt to find the admins password using sql injection!</h2>
 @endif
 
-<strong>Difficulty: {{ $attack->getDifficulty() }}</strong>
+<strong>Difficulty: {{ $attack->getDifficulty() }}/5</strong>
 
 @if (!empty($result))
     Result = {{var_dump($result)}}    

--- a/resources/views/minigame/sqlinjection.blade.php
+++ b/resources/views/minigame/sqlinjection.blade.php
@@ -33,7 +33,7 @@
     </div>
 </form>
 
-@if($attack->calculated_success_chance > 1)
+@if($attack->getDifficulty() > 1)
     <form method="POST" action="/attack/sqlinjectioncheck">
         @csrf
         <div class="form-group row">

--- a/resources/views/minigame/sqlinjection.blade.php
+++ b/resources/views/minigame/sqlinjection.blade.php
@@ -3,13 +3,13 @@
 @section('title', 'SQL Injection Attack')
 
 @section('pagecontent')
-@if ($attack->calculated_success_chance <= 1)
+@if ($attack->getDifficulty() <= 1)
     <h2>Attempt to cause a SQL error!</h2>
-@elseif ($attack->calculated_success_chance > 1)
+@elseif ($attack->getDifficulty() > 1)
     <h2>Attempt to find the admins password using sql injection!</h2>
 @endif
 
-<strong>Difficulty: {{ $attack->calculated_success_chance }}</strong>
+<strong>Difficulty: {{ $attack->getDifficulty() }}</strong>
 
 @if (!empty($result))
     Result = {{var_dump($result)}}    

--- a/resources/views/minigame/sqlinjection.blade.php
+++ b/resources/views/minigame/sqlinjection.blade.php
@@ -3,13 +3,13 @@
 @section('title', 'SQL Injection Attack')
 
 @section('pagecontent')
-@if ($attack->calculated_difficulty <= 1)
+@if ($attack->calculated_success_chance <= 1)
     <h2>Attempt to cause a SQL error!</h2>
-@elseif ($attack->calculated_difficulty > 1)
+@elseif ($attack->calculated_success_chance > 1)
     <h2>Attempt to find the admins password using sql injection!</h2>
 @endif
 
-<strong>Difficulty: {{ $attack->calculated_difficulty }}</strong>
+<strong>Difficulty: {{ $attack->calculated_success_chance }}</strong>
 
 @if (!empty($result))
     Result = {{var_dump($result)}}    
@@ -33,7 +33,7 @@
     </div>
 </form>
 
-@if($attack->calculated_difficulty > 1)
+@if($attack->calculated_success_chance > 1)
     <form method="POST" action="/attack/sqlinjectioncheck">
         @csrf
         <div class="form-group row">

--- a/resources/views/minigame/synflood.blade.php
+++ b/resources/views/minigame/synflood.blade.php
@@ -5,7 +5,7 @@
 @section('pagecontent')
 <h4>Attack Choice </h4>
 @if(!empty($attack))
-Difficulty: {{$attack->difficulty }}/5 <br>
+Difficulty: {{$attack->getDifficulty() }}/5 <br>
 
 <form class="synFloodForm" method="POST" action="/attack/synflood">
         @csrf
@@ -13,7 +13,7 @@ Difficulty: {{$attack->difficulty }}/5 <br>
             <?php function random($attack){
                 $randInt = rand(1,4);
                 $val = 0;
-                if($randInt > $attack->difficulty - 1){
+                if($randInt > $attack->getDifficulty() - 1){
                     $val = 1;
                 }
                 return $val;

--- a/tests/Feature/SQLMinigameFeatureTest.php
+++ b/tests/Feature/SQLMinigameFeatureTest.php
@@ -24,7 +24,7 @@ class SQLMinigameFeatureTest extends TestCase {
 
     public function testSqlNonInjectionInput(){
         $attack = $this->createAttack();
-        $attack->calculated_success_chance = 2;
+        $attack->calculated_success_chance = 0.6;
         Attack::updateAttack($attack);
         $response = $this->post('/attack/sqlinjection', [
             'attID' => $attack->id,
@@ -36,7 +36,7 @@ class SQLMinigameFeatureTest extends TestCase {
 
     public function testSqlInjectionLevel1Display(){
         $attack = $this->createAttack();
-        $attack->calculated_success_chance = 1;
+        $attack->calculated_success_chance = 0.8;
         Attack::updateAttack($attack);
         $response = $this->post('/redteam/savePayload', [
             'attID' => $attack->id,
@@ -49,7 +49,7 @@ class SQLMinigameFeatureTest extends TestCase {
 
     public function testSqlInjectionLevel1(){
         $attack = $this->createAttack();
-        $attack->calculated_success_chance = 1;
+        $attack->calculated_success_chance = 0.8;
         Attack::updateAttack($attack);
         $response = $this->post('/attack/sqlinjection', [
             'attID' => $attack->id,
@@ -61,7 +61,7 @@ class SQLMinigameFeatureTest extends TestCase {
 
     public function testSqlInjectionLevel2Display(){
         $attack = $this->createAttack();
-        $attack->calculated_success_chance = 2;
+        $attack->calculated_success_chance = 0.6;
         Attack::updateAttack($attack);
         $response = $this->post('/redteam/savePayload', [
             'attID' => $attack->id,
@@ -74,7 +74,7 @@ class SQLMinigameFeatureTest extends TestCase {
 
     public function testSqlInjectionLevel2(){
         $attack = $this->createAttack();
-        $attack->calculated_success_chance = 2;
+        $attack->calculated_success_chance = 0.6;
         Attack::updateAttack($attack);
         
         $response = $this->post('/attack/sqlinjection', [

--- a/tests/Feature/SQLMinigameFeatureTest.php
+++ b/tests/Feature/SQLMinigameFeatureTest.php
@@ -24,7 +24,7 @@ class SQLMinigameFeatureTest extends TestCase {
 
     public function testSqlNonInjectionInput(){
         $attack = $this->createAttack();
-        $attack->calculated_difficulty = 2;
+        $attack->calculated_success_chance = 2;
         Attack::updateAttack($attack);
         $response = $this->post('/attack/sqlinjection', [
             'attID' => $attack->id,
@@ -36,7 +36,7 @@ class SQLMinigameFeatureTest extends TestCase {
 
     public function testSqlInjectionLevel1Display(){
         $attack = $this->createAttack();
-        $attack->calculated_difficulty = 1;
+        $attack->calculated_success_chance = 1;
         Attack::updateAttack($attack);
         $response = $this->post('/redteam/savePayload', [
             'attID' => $attack->id,
@@ -49,7 +49,7 @@ class SQLMinigameFeatureTest extends TestCase {
 
     public function testSqlInjectionLevel1(){
         $attack = $this->createAttack();
-        $attack->calculated_difficulty = 1;
+        $attack->calculated_success_chance = 1;
         Attack::updateAttack($attack);
         $response = $this->post('/attack/sqlinjection', [
             'attID' => $attack->id,
@@ -61,7 +61,7 @@ class SQLMinigameFeatureTest extends TestCase {
 
     public function testSqlInjectionLevel2Display(){
         $attack = $this->createAttack();
-        $attack->calculated_difficulty = 2;
+        $attack->calculated_success_chance = 2;
         Attack::updateAttack($attack);
         $response = $this->post('/redteam/savePayload', [
             'attID' => $attack->id,
@@ -74,7 +74,7 @@ class SQLMinigameFeatureTest extends TestCase {
 
     public function testSqlInjectionLevel2(){
         $attack = $this->createAttack();
-        $attack->calculated_difficulty = 2;
+        $attack->calculated_success_chance = 2;
         Attack::updateAttack($attack);
         
         $response = $this->post('/attack/sqlinjection', [

--- a/tests/Unit/AttackTest.php
+++ b/tests/Unit/AttackTest.php
@@ -8,9 +8,7 @@ use App\Models\Team;
 use App\Models\Inventory;
 use App\Exceptions\AttackNotFoundException;
 use App\Exceptions\TeamNotFoundException;
-use App\Models\Attacks\MalvertiseAttack;
 use App\Models\Attacks\SQLInjectionAttack;
-use App\Models\Attacks\SynFloodAttack;
 use App\Models\Assets\AccessTokenAsset;
 use App\Models\Bonus;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -184,7 +182,7 @@ class AttackTest extends TestCase {
         $blue = Team::factory()->create();
         Attack::create('SQLInjection', $red->id, $blue->id);
         $attack = Attack::find(1);
-        $attack->calculated_detection_risk = 5;
+        $attack->calculated_detection_chance = 5;
         Attack::updateAttack($attack);
         $attack->calculateDetected();
         $this->assertTrue($attack->detection_level >= 1);
@@ -195,7 +193,7 @@ class AttackTest extends TestCase {
         $blue = Team::factory()->create();
         Attack::create('SQLInjection', $red->id, $blue->id);
         $attack = Attack::find(1);
-        $attack->calculated_detection_risk = 0;
+        $attack->calculated_detection_chance = 0;
         Attack::updateAttack($attack);
         $attack->calculateDetected();
         $this->assertEquals(0, $attack->detection_level);
@@ -207,7 +205,7 @@ class AttackTest extends TestCase {
         Attack::create('SQLInjection', $red->id, $blue->id);
         $attack = Attack::find(1);
         $attack->success = true;
-        $attack->calculated_detection_risk = 5;
+        $attack->calculated_detection_chance = 5;
         Attack::updateAttack($attack);
         $attack->calculateDetected();
         $this->assertNotEquals(0, $attack->detection_level);
@@ -220,15 +218,15 @@ class AttackTest extends TestCase {
         Attack::create('SQLInjection', $red->id, $blue->id);
         $attack = Attack::find(1);
 
-        $this->assertEquals($baseAttack->difficulty, $attack->difficulty);
+        $this->assertEquals($baseAttack->success_chance, $attack->success_chance);
         $attack->changeDifficulty(10);
-        $this->assertEquals(5, $attack->calculated_difficulty);
+        $this->assertEquals(5, $attack->calculated_success_chance);
         $attack->changeDifficulty(-10);
-        $this->assertEquals(1, $attack->calculated_difficulty);
-        $attack->difficulty = 5;
-        $attack->calculated_difficulty = 5;
+        $this->assertEquals(1, $attack->calculated_success_chance);
+        $attack->success_chance = 5;
+        $attack->calculated_success_chance = 5;
         $attack->changeDifficulty(-.2);
-        $this->assertEquals(4, $attack->calculated_difficulty);
+        $this->assertEquals(4, $attack->calculated_success_chance);
     }
 
     public function testChangeDetectionRisk() {
@@ -238,13 +236,13 @@ class AttackTest extends TestCase {
         Attack::create('SQLInjection', $red->id, $blue->id);
         $attack = Attack::find(1);
         $attack->changeDetectionRisk(10);
-        $this->assertEquals(5, $attack->calculated_detection_risk);
+        $this->assertEquals(5, $attack->calculated_detection_chance);
         $attack->changeDetectionRisk(-10);
-        $this->assertEquals(0, $attack->calculated_detection_risk);
-        $attack->detection_risk = 5;
-        $attack->calculated_detection_risk = 5;
+        $this->assertEquals(0, $attack->calculated_detection_chance);
+        $attack->detection_chance = 5;
+        $attack->calculated_detection_chance = 5;
         $attack->changeDetectionRisk(-.2);
-        $this->assertEquals(4, $attack->calculated_detection_risk);
+        $this->assertEquals(4, $attack->calculated_detection_chance);
     }
 
     public function testCreateAttack() {
@@ -273,11 +271,11 @@ class AttackTest extends TestCase {
         $red = Team::factory()->red()->create();
         $blue = Team::factory()->create();
         $attack = Attack::create('SynFlood', $red->id, $blue->id);
-        $attack->difficulty = 1;
+        $attack->success_chance = 1;
         $att = Attack::updateAttack($attack);
-        $this->assertEquals(1, $att->difficulty);
+        $this->assertEquals(1, $att->success_chance);
         $dbAttack = Attack::find(1);
-        $this->assertEquals(1, $dbAttack->difficulty);
+        $this->assertEquals(1, $dbAttack->success_chance);
     }
 
     public function testInternalOnPreAttackNoToken(){
@@ -309,12 +307,12 @@ class AttackTest extends TestCase {
         $blue = Team::factory()->create();
         Inventory::factory()->create(['asset_name' => 'SecurityAnalyst', 'team_id' => $blue->id]);
         $attack = Attack::create('SynFlood', $red->id, $blue->id);
-        $attack->calculated_detection_risk = 5;
-        $attack->analysis_risk = 2;
-        $attack->calculated_analysis_risk = 2;
-        $analysis_risk = $attack->calculated_analysis_risk;
+        $attack->calculated_detection_chance = 5;
+        $attack->analysis_chance = 2;
+        $attack->calculated_analysis_chance = 2;
+        $analysis_risk = $attack->calculated_analysis_chance;
         $attack->onPreAttack();
-        $this->assertEquals($analysis_risk + (.3 * $analysis_risk), $attack->calculated_analysis_risk);
+        $this->assertEquals($analysis_risk + (.3 * $analysis_risk), $attack->calculated_analysis_chance);
     }
 
     public function testGetName(){
@@ -395,8 +393,8 @@ class AttackTest extends TestCase {
         $red = Team::factory()->red()->create();
         $blue = Team::factory()->create();
         $attack = Attack::create('SQLInjection', $red->id, $blue->id);
-        $attack->detection_risk = 0; //Shouldn't be detected
-        $attack->difficult = 0; //Attack will succeed
+        $attack->detection_chance = 0; //Shouldn't be detected
+        $attack->success_chance = 0; //Attack will succeed
         Attack::updateAttack($attack);
         $attack->onPreAttack();
         

--- a/tests/Unit/AttackTest.php
+++ b/tests/Unit/AttackTest.php
@@ -219,29 +219,29 @@ class AttackTest extends TestCase {
         $attack = Attack::find(1);
 
         $this->assertEquals($baseAttack->success_chance, $attack->success_chance);
-        $attack->changeDifficulty(10);
+        $attack->changeSuccessChance(10);
         $this->assertEquals(1, $attack->calculated_success_chance);
-        $attack->changeDifficulty(-10);
+        $attack->changeSuccessChance(-10);
         $this->assertEquals(0.2, $attack->calculated_success_chance);
         $attack->success_chance = 1;
         $attack->calculated_success_chance = 1;
-        $attack->changeDifficulty(-.2);
+        $attack->changeSuccessChance(-.2);
         $this->assertEquals(.8, $attack->calculated_success_chance);
     }
 
-    public function testChangeDetectionRisk() {
+    public function testChangeDetectionChance() {
         $baseAttack = new SQLInjectionAttack;
         $red = Team::factory()->red()->create();
         $blue = Team::factory()->create();
         Attack::create('SQLInjection', $red->id, $blue->id);
         $attack = Attack::find(1);
-        $attack->changeDetectionRisk(10);
+        $attack->changeDetectionChance(10);
         $this->assertEquals(1, $attack->calculated_detection_chance);
-        $attack->changeDetectionRisk(-10);
+        $attack->changeDetectionChance(-10);
         $this->assertEquals(0.2, $attack->calculated_detection_chance);
         $attack->detection_chance = 1;
         $attack->calculated_detection_chance = 1;
-        $attack->changeDetectionRisk(-.2);
+        $attack->changeDetectionChance(-.2);
         $this->assertEquals(0.8, $attack->calculated_detection_chance);
     }
 
@@ -302,7 +302,7 @@ class AttackTest extends TestCase {
         $this->assertTrue($attack->possible);
     }
 
-    public function testAnalystAddsAnalysisRiskAttacks(){
+    public function testAnalystAddsAnalysisChanceAttacks(){
         $red = Team::factory()->red()->create();
         $blue = Team::factory()->create();
         Inventory::factory()->create(['asset_name' => 'SecurityAnalyst', 'team_id' => $blue->id]);

--- a/tests/Unit/AttackTest.php
+++ b/tests/Unit/AttackTest.php
@@ -222,7 +222,7 @@ class AttackTest extends TestCase {
         $attack->changeSuccessChance(10);
         $this->assertEquals(1, $attack->calculated_success_chance);
         $attack->changeSuccessChance(-10);
-        $this->assertEquals(0.2, $attack->calculated_success_chance);
+        $this->assertEquals(0, $attack->calculated_success_chance);
         $attack->success_chance = 1;
         $attack->calculated_success_chance = 1;
         $attack->changeSuccessChance(-.2);
@@ -238,7 +238,7 @@ class AttackTest extends TestCase {
         $attack->changeDetectionChance(10);
         $this->assertEquals(1, $attack->calculated_detection_chance);
         $attack->changeDetectionChance(-10);
-        $this->assertEquals(0.2, $attack->calculated_detection_chance);
+        $this->assertEquals(0, $attack->calculated_detection_chance);
         $attack->detection_chance = 1;
         $attack->calculated_detection_chance = 1;
         $attack->changeDetectionChance(-.2);
@@ -418,7 +418,7 @@ class AttackTest extends TestCase {
         $attack->calculated_success_chance = 0;
         $this->assertEquals(5, $attack->getDifficulty());
         $attack->calculated_success_chance = 1;
-        $this->assertEquals(0, $attack->getDifficulty());
+        $this->assertEquals(1, $attack->getDifficulty());
     }
 
     public function testGetDifficultyRounding() {
@@ -428,8 +428,10 @@ class AttackTest extends TestCase {
         $attack->calculated_success_chance = 0.10;
         $this->assertEquals(5, $attack->getDifficulty());
         $attack->calculated_success_chance = 0.95;
-        $this->assertEquals(0, $attack->getDifficulty()); 
+        $this->assertEquals(1, $attack->getDifficulty()); 
     }
+
+    //Targeted Prereq Handler tests
   
     public function testTargetedPrereqNoPrereq(){
         $red = Team::factory()->red()->create();

--- a/tests/Unit/AttackTest.php
+++ b/tests/Unit/AttackTest.php
@@ -222,7 +222,7 @@ class AttackTest extends TestCase {
         $attack->changeDifficulty(10);
         $this->assertEquals(1, $attack->calculated_success_chance);
         $attack->changeDifficulty(-10);
-        $this->assertEquals(0.01, $attack->calculated_success_chance);
+        $this->assertEquals(0.2, $attack->calculated_success_chance);
         $attack->success_chance = 1;
         $attack->calculated_success_chance = 1;
         $attack->changeDifficulty(-.2);
@@ -238,7 +238,7 @@ class AttackTest extends TestCase {
         $attack->changeDetectionRisk(10);
         $this->assertEquals(1, $attack->calculated_detection_chance);
         $attack->changeDetectionRisk(-10);
-        $this->assertEquals(0.01, $attack->calculated_detection_chance);
+        $this->assertEquals(0.2, $attack->calculated_detection_chance);
         $attack->detection_chance = 1;
         $attack->calculated_detection_chance = 1;
         $attack->changeDetectionRisk(-.2);

--- a/tests/Unit/AttackTest.php
+++ b/tests/Unit/AttackTest.php
@@ -420,4 +420,14 @@ class AttackTest extends TestCase {
         $attack->calculated_success_chance = 1;
         $this->assertEquals(0, $attack->getDifficulty());
     }
+
+    public function testGetDifficultyRounding() {
+        $red = Team::factory()->red()->create();
+        $blue = Team::factory()->create();
+        $attack = Attack::create('SQLInjection', $red->id, $blue->id);
+        $attack->calculated_success_chance = 0.10;
+        $this->assertEquals(5, $attack->getDifficulty());
+        $attack->calculated_success_chance = 0.95;
+        $this->assertEquals(0, $attack->getDifficulty()); 
+    }
 }

--- a/tests/Unit/AttackTest.php
+++ b/tests/Unit/AttackTest.php
@@ -182,7 +182,7 @@ class AttackTest extends TestCase {
         $blue = Team::factory()->create();
         Attack::create('SQLInjection', $red->id, $blue->id);
         $attack = Attack::find(1);
-        $attack->calculated_detection_chance = 5;
+        $attack->calculated_detection_chance = 1;
         Attack::updateAttack($attack);
         $attack->calculateDetected();
         $this->assertTrue($attack->detection_level >= 1);
@@ -205,7 +205,7 @@ class AttackTest extends TestCase {
         Attack::create('SQLInjection', $red->id, $blue->id);
         $attack = Attack::find(1);
         $attack->success = true;
-        $attack->calculated_detection_chance = 5;
+        $attack->calculated_detection_chance = 1;
         Attack::updateAttack($attack);
         $attack->calculateDetected();
         $this->assertNotEquals(0, $attack->detection_level);
@@ -220,13 +220,13 @@ class AttackTest extends TestCase {
 
         $this->assertEquals($baseAttack->success_chance, $attack->success_chance);
         $attack->changeDifficulty(10);
-        $this->assertEquals(5, $attack->calculated_success_chance);
-        $attack->changeDifficulty(-10);
         $this->assertEquals(1, $attack->calculated_success_chance);
-        $attack->success_chance = 5;
-        $attack->calculated_success_chance = 5;
+        $attack->changeDifficulty(-10);
+        $this->assertEquals(0.01, $attack->calculated_success_chance);
+        $attack->success_chance = 1;
+        $attack->calculated_success_chance = 1;
         $attack->changeDifficulty(-.2);
-        $this->assertEquals(4, $attack->calculated_success_chance);
+        $this->assertEquals(.8, $attack->calculated_success_chance);
     }
 
     public function testChangeDetectionRisk() {
@@ -236,13 +236,13 @@ class AttackTest extends TestCase {
         Attack::create('SQLInjection', $red->id, $blue->id);
         $attack = Attack::find(1);
         $attack->changeDetectionRisk(10);
-        $this->assertEquals(5, $attack->calculated_detection_chance);
+        $this->assertEquals(1, $attack->calculated_detection_chance);
         $attack->changeDetectionRisk(-10);
-        $this->assertEquals(0, $attack->calculated_detection_chance);
-        $attack->detection_chance = 5;
-        $attack->calculated_detection_chance = 5;
+        $this->assertEquals(0.01, $attack->calculated_detection_chance);
+        $attack->detection_chance = 1;
+        $attack->calculated_detection_chance = 1;
         $attack->changeDetectionRisk(-.2);
-        $this->assertEquals(4, $attack->calculated_detection_chance);
+        $this->assertEquals(0.8, $attack->calculated_detection_chance);
     }
 
     public function testCreateAttack() {
@@ -307,9 +307,9 @@ class AttackTest extends TestCase {
         $blue = Team::factory()->create();
         Inventory::factory()->create(['asset_name' => 'SecurityAnalyst', 'team_id' => $blue->id]);
         $attack = Attack::create('SynFlood', $red->id, $blue->id);
-        $attack->calculated_detection_chance = 5;
-        $attack->analysis_chance = 2;
-        $attack->calculated_analysis_chance = 2;
+        $attack->calculated_detection_chance = 1;
+        $attack->analysis_chance = 0.4;
+        $attack->calculated_analysis_chance = 0.4;
         $analysis_risk = $attack->calculated_analysis_chance;
         $attack->onPreAttack();
         $this->assertEquals($analysis_risk + (.3 * $analysis_risk), $attack->calculated_analysis_chance);
@@ -394,7 +394,7 @@ class AttackTest extends TestCase {
         $blue = Team::factory()->create();
         $attack = Attack::create('SQLInjection', $red->id, $blue->id);
         $attack->detection_chance = 0; //Shouldn't be detected
-        $attack->success_chance = 0; //Attack will succeed
+        $attack->success_chance = 1; //Attack will succeed
         Attack::updateAttack($attack);
         $attack->onPreAttack();
         

--- a/tests/Unit/AttackTest.php
+++ b/tests/Unit/AttackTest.php
@@ -408,4 +408,16 @@ class AttackTest extends TestCase {
         $attack->onAttackComplete();
         $this->assertEquals(1, $attack->detection_level);
     }
+
+    public function testGetDifficulty() {
+        $red = Team::factory()->red()->create();
+        $blue = Team::factory()->create();
+        $attack = Attack::create('SQLInjection', $red->id, $blue->id);
+        $attack->calculated_success_chance = 0.20;
+        $this->assertEquals(4, $attack->getDifficulty());
+        $attack->calculated_success_chance = 0;
+        $this->assertEquals(5, $attack->getDifficulty());
+        $attack->calculated_success_chance = 1;
+        $this->assertEquals(0, $attack->getDifficulty());
+    }
 }

--- a/tests/Unit/Attacks/MalvertiseAttackTest.php
+++ b/tests/Unit/Attacks/MalvertiseAttackTest.php
@@ -59,7 +59,7 @@ class MalvertiseAttackTest extends TestCase {
         $response = $controller->malvertise($request);
         $attackAfter = Attack::find($attack->id);
         $this->assertEquals($attack->name, $attackAfter->name);
-        $this->assertEquals($attack->difficulty, $attackAfter->difficulty);
+        $this->assertEquals($attack->success_chance, $attackAfter->success_chance);
         $this->assertEquals(1, $attackAfter->success);
     }
 
@@ -74,7 +74,7 @@ class MalvertiseAttackTest extends TestCase {
         $response = $controller->malvertise($request);
         $attackAfter = Attack::find($attack->id);
         $this->assertEquals($attack->name, $attackAfter->name);
-        $this->assertEquals($attack->difficulty, $attackAfter->difficulty);
+        $this->assertEquals($attack->success_chance, $attackAfter->success_chance);
         $this->assertEquals(0, $attackAfter->success);
     }
 }

--- a/tests/Unit/Attacks/SQLInjectionAttackTest.php
+++ b/tests/Unit/Attacks/SQLInjectionAttackTest.php
@@ -62,16 +62,16 @@ class SQLInjectionAttackTest extends TestCase {
         Inventory::factory()->create(['team_id' => $attack->redteam, 'asset_name' => $vpn->class_name]);
         $expected = $attack;
         $expected->possible = true;
-        $expected->difficulty = 1;
+        $expected->success_chance = 1;
         $attack->onPreAttack();
         $attack = Attack::get($attack->class_name, $attack->redteam, $attack->blueteam);
         $this->assertEquals($expected->possible, $attack->possible);
-        $this->assertEquals($expected->difficulty, $attack->difficulty);
+        $this->assertEquals($expected->success_chance, $attack->success_chance);
     }
 
     public function testMinigameDifficultyFiveAlwaysFails(){
         $attack = $this->createAttackAndTeams();
-        $attack->difficulty = 5;
+        $attack->success_chance = 5;
         Attack::updateAttack($attack);
         $attack->onPreAttack();
         $sqldatabase = new SQLDatabaseAsset;
@@ -84,7 +84,7 @@ class SQLInjectionAttackTest extends TestCase {
         $response = $controller->sqlInjection($request);
         $attackAfter = Attack::find(1);
         $this->assertEquals($attack->name, $attackAfter->name);
-        $this->assertEquals($attack->difficulty, $attackAfter->difficulty);
+        $this->assertEquals($attack->success_chance, $attackAfter->success_chance);
         $this->assertEquals(0, $attackAfter->success);
     }
 }

--- a/tests/Unit/Attacks/SQLInjectionAttackTest.php
+++ b/tests/Unit/Attacks/SQLInjectionAttackTest.php
@@ -62,7 +62,7 @@ class SQLInjectionAttackTest extends TestCase {
         Inventory::factory()->create(['team_id' => $attack->redteam, 'asset_name' => $vpn->class_name]);
         $expected = $attack;
         $expected->possible = true;
-        $expected->success_chance = 1;
+        $expected->success_chance = 0.8;
         $attack->onPreAttack();
         $attack = Attack::get($attack->class_name, $attack->redteam, $attack->blueteam);
         $this->assertEquals($expected->possible, $attack->possible);
@@ -71,7 +71,7 @@ class SQLInjectionAttackTest extends TestCase {
 
     public function testMinigameDifficultyFiveAlwaysFails(){
         $attack = $this->createAttackAndTeams();
-        $attack->success_chance = 5;
+        $attack->success_chance = 0;
         Attack::updateAttack($attack);
         $attack->onPreAttack();
         $sqldatabase = new SQLDatabaseAsset;

--- a/tests/Unit/Attacks/SynFloodAttackTest.php
+++ b/tests/Unit/Attacks/SynFloodAttackTest.php
@@ -42,7 +42,7 @@ class SynFloodAttackTest extends TestCase {
         $firewall = new FirewallAsset;
         Inventory::factory()->create(['team_id' => $attack->blueteam, 'asset_name' => $firewall->class_name]);
         $expected = $attack;
-        $expected->success_chance += 2;
+        $expected->success_chance -= 0.4;
         $attack->onPreAttack();
         $this->assertEquals($expected, $attack);
     }

--- a/tests/Unit/Attacks/SynFloodAttackTest.php
+++ b/tests/Unit/Attacks/SynFloodAttackTest.php
@@ -42,7 +42,7 @@ class SynFloodAttackTest extends TestCase {
         $firewall = new FirewallAsset;
         Inventory::factory()->create(['team_id' => $attack->blueteam, 'asset_name' => $firewall->class_name]);
         $expected = $attack;
-        $expected->difficulty += 2;
+        $expected->success_chance += 2;
         $attack->onPreAttack();
         $this->assertEquals($expected, $attack);
     }
@@ -59,7 +59,7 @@ class SynFloodAttackTest extends TestCase {
         $response = $controller->synFlood($request);
         $attackAfter = Attack::find($attack->id);
         $this->assertEquals($attack->name, $attackAfter->name);
-        $this->assertEquals($attack->difficulty, $attackAfter->difficulty);
+        $this->assertEquals($attack->success_chance, $attackAfter->success_chance);
         $this->assertEquals(1, $attackAfter->success);
     }
 
@@ -75,7 +75,7 @@ class SynFloodAttackTest extends TestCase {
         $response = $controller->synFlood($request);
         $attackAfter = Attack::find($attack->id);
         $this->assertEquals($attack->name, $attackAfter->name);
-        $this->assertEquals($attack->difficulty, $attackAfter->difficulty);
+        $this->assertEquals($attack->success_chance, $attackAfter->success_chance);
         $this->assertEquals(0, $attackAfter->success);
     }
 
@@ -91,7 +91,7 @@ class SynFloodAttackTest extends TestCase {
         $response = $controller->synFlood($request);
         $attackAfter = Attack::find($attack->id);
         $this->assertEquals($attack->name, $attackAfter->name);
-        $this->assertEquals($attack->difficulty, $attackAfter->difficulty);
+        $this->assertEquals($attack->success_chance, $attackAfter->success_chance);
         $this->assertEquals(0, $attackAfter->success);
     }
 
@@ -107,7 +107,7 @@ class SynFloodAttackTest extends TestCase {
         $response = $controller->synFlood($request);
         $attackAfter = Attack::find($attack->id);
         $this->assertEquals($attack->name, $attackAfter->name);
-        $this->assertEquals($attack->difficulty, $attackAfter->difficulty);
+        $this->assertEquals($attack->success_chance, $attackAfter->success_chance);
         $this->assertEquals(0, $attackAfter->success);
     }
 

--- a/tests/Unit/BonusTest.php
+++ b/tests/Unit/BonusTest.php
@@ -145,7 +145,7 @@ class BonusTest extends TestCase {
         $diffBefore = $attack->calculated_success_chance;
         $attack->onPreAttack();
         $this->assertTrue($attack->possible);
-        $this->assertEquals($diffBefore/2, $attack->calculated_success_chance);
+        $this->assertEquals($diffBefore * 0.5, $attack->calculated_success_chance);
     }
 
     public function testChanceToRemove(){

--- a/tests/Unit/BonusTest.php
+++ b/tests/Unit/BonusTest.php
@@ -133,19 +133,19 @@ class BonusTest extends TestCase {
         $this->assertEmpty(Bonus::all());
     }
 
-    public function testDiffOnPre(){
+    public function testDifficultyReductionOnPreAttack(){
         $team = $this->createTeams();
         $blueteam = Team::all()->where('blue','=',1)->first();
         $tags = ["DifficultyDeduction"];
         $bonus = $this->createBonus($team->id, $tags);
-        $bonus->percentDiffDeducted = .5;
+        $bonus->percentDiffDeducted = 50;
         $bonus->target_id = $blueteam->id;
         $bonus->update();
         $attack = Attack::create('SynFlood', $team->id, $blueteam->id);
         $diffBefore = $attack->calculated_success_chance;
         $attack->onPreAttack();
         $this->assertTrue($attack->possible);
-        $this->assertEquals($diffBefore - 1, $attack->calculated_success_chance);
+        $this->assertEquals($diffBefore/2, $attack->calculated_success_chance);
     }
 
     public function testChanceToRemove(){

--- a/tests/Unit/BonusTest.php
+++ b/tests/Unit/BonusTest.php
@@ -142,10 +142,10 @@ class BonusTest extends TestCase {
         $bonus->target_id = $blueteam->id;
         $bonus->update();
         $attack = Attack::create('SynFlood', $team->id, $blueteam->id);
-        $diffBefore = $attack->calculated_difficulty;
+        $diffBefore = $attack->calculated_success_chance;
         $attack->onPreAttack();
         $this->assertTrue($attack->possible);
-        $this->assertEquals($diffBefore - 1, $attack->calculated_difficulty);
+        $this->assertEquals($diffBefore - 1, $attack->calculated_success_chance);
     }
 
     public function testChanceToRemove(){

--- a/tests/Unit/PayloadTest.php
+++ b/tests/Unit/PayloadTest.php
@@ -34,7 +34,7 @@ class PayloadTest extends TestCase {
     public function testPayloadOnPreAttackCanIncreaseSuccess() {
         $attack = $this->createTeamsAndAttack();
         $initialDiff = $attack->calculated_success_chance;
-        $this->assertEquals(0.4, $attack->calculated_success_chance);
+        $this->assertEquals(0.6, $attack->calculated_success_chance);
         $payload = new Payload;
         $payload->percentIncreasedSuccess = 20;
         $payload->onPreAttack($attack);

--- a/tests/Unit/PayloadTest.php
+++ b/tests/Unit/PayloadTest.php
@@ -33,13 +33,13 @@ class PayloadTest extends TestCase {
 
     public function testPayloadOnPreAttackCanIncreaseSuccess() {
         $attack = $this->createTeamsAndAttack();
-        $initialDiff = $attack->calculated_difficulty;
-        $this->assertEquals(2, $attack->calculated_difficulty);
+        $initialDiff = $attack->calculated_success_chance;
+        $this->assertEquals(2, $attack->calculated_success_chance);
         $payload = new Payload;
         $payload->percentIncreasedSuccess = .2;
         $payload->onPreAttack($attack);
         $attack->fresh();
-        $this->assertEquals($initialDiff * .8, $attack->calculated_difficulty);
+        $this->assertEquals($initialDiff * .8, $attack->calculated_success_chance);
     }
 
     public function testGetPayloadByTag() {

--- a/tests/Unit/PayloadTest.php
+++ b/tests/Unit/PayloadTest.php
@@ -34,12 +34,12 @@ class PayloadTest extends TestCase {
     public function testPayloadOnPreAttackCanIncreaseSuccess() {
         $attack = $this->createTeamsAndAttack();
         $initialDiff = $attack->calculated_success_chance;
-        $this->assertEquals(2, $attack->calculated_success_chance);
+        $this->assertEquals(0.4, $attack->calculated_success_chance);
         $payload = new Payload;
-        $payload->percentIncreasedSuccess = .2;
+        $payload->percentIncreasedSuccess = 20;
         $payload->onPreAttack($attack);
         $attack->fresh();
-        $this->assertEquals($initialDiff * .8, $attack->calculated_success_chance);
+        $this->assertEquals($initialDiff * 1.2, $attack->calculated_success_chance);
     }
 
     public function testGetPayloadByTag() {

--- a/tests/Unit/RedTeamTest.php
+++ b/tests/Unit/RedTeamTest.php
@@ -136,8 +136,8 @@ class RedTeamTest extends TestCase
         $this->assertEquals($team->id, $response->redteam->id);
         $this->assertEquals($team->id, $response->attack->redteam);
         $this->assertEquals($target->id, $response->attack->blueteam);
-        $this->assertFalse(empty($response->attack->difficulty));
-        $this->assertFalse(empty($response->attack->detection_risk));
+        $this->assertFalse(empty($response->attack->success_chance));
+        $this->assertFalse(empty($response->attack->detection_chance));
         $this->assertTrue($response->attack->possible);
         $this->assertEquals("Syn Flood", $response->attack->name);
     }


### PR DESCRIPTION
Changed "difficulty" to success_chance. Difficulty was 0-5, 0 always succeeds. Success_chance is 30% chance of success = 0.3. 
Also changed stuff like "analysis_risk" to "analysis_chance" so it was consistent across the board for these variables. Decimals also get used for detection, analysis, and attribution rather than the 0-5 scale. 

Refactored some stuff related to probability calculations in Attack model, some code was repeated across 4 methods.

Added getDifficulty() which converts the calculated_success_chance to the original 0-5 difficulty scale for use with minigames.

Some more small changes like adding descriptions to buyable assets. Completely forgot about it in my last branch.