### PR TITLE
Add missing payloads and asset descriptions

### DIFF
--- a/app/Models/Assets/AccessTokenAsset.php
+++ b/app/Models/Assets/AccessTokenAsset.php
@@ -19,6 +19,7 @@ class AccessTokenAsset extends Asset
     public $_buyable = 0;
     public $_purchase_cost = 0;
     public $_ownership_cost = 0;
+    public $_description = "Access Tokens give access to new attacks. Not purchasable.";
 
     public function onPreAttack($attack)
     {

--- a/app/Models/Assets/InsiderAsset.php
+++ b/app/Models/Assets/InsiderAsset.php
@@ -13,6 +13,7 @@ class InsiderAsset extends Asset
     public $_tags    = ['AccessToken','Targeted'];
     public $_blue = 0;
     public $_buyable = 0;
+    public $_description = "Man on the inside who is working for a red team.";
 
     public function onPreAttack($attack)
     {

--- a/app/Models/Assets/TestAttackAsset.php
+++ b/app/Models/Assets/TestAttackAsset.php
@@ -12,7 +12,7 @@ class TestAttackAsset extends Asset
     public $_class_name = "TestAttack";
     public $_tags    = ["offensive tag 1", "offensive tag 2"];
     public $_blue = 0;
-    public $_buyable = 1;
+    public $_buyable = 0;
     public $_purchase_cost = 100;
     public $_ownership_cost = 0;
 

--- a/app/Models/Assets/TestAttackAsset.php
+++ b/app/Models/Assets/TestAttackAsset.php
@@ -3,7 +3,6 @@
 namespace App\Models\Assets;
 
 use App\Models\Asset;
-use App\Models\Attack;
 
 class TestAttackAsset extends Asset 
 {
@@ -15,6 +14,7 @@ class TestAttackAsset extends Asset
     public $_buyable = 0;
     public $_purchase_cost = 100;
     public $_ownership_cost = 0;
+    public $_description = "Test asset, you're not supposed to see this.";
 
     public function onPreAttack($attack)
     {

--- a/app/Models/Assets/TestDefenseAsset.php
+++ b/app/Models/Assets/TestDefenseAsset.php
@@ -11,7 +11,7 @@ class TestDefenseAsset extends Asset
     public $_class_name = "TestDefense";
     public $_tags    = ["defensive tag 1"];
     public $_blue = 1;
-    public $_buyable = 1;
+    public $_buyable = 0;
     public $_purchase_cost = 100;
     public $_ownership_cost = 0;
 

--- a/app/Models/Assets/TestDefenseAsset.php
+++ b/app/Models/Assets/TestDefenseAsset.php
@@ -14,6 +14,7 @@ class TestDefenseAsset extends Asset
     public $_buyable = 0;
     public $_purchase_cost = 100;
     public $_ownership_cost = 0;
+    public $_description = "Test asset, you're not supposed to see this.";
 
     public function onPreAttack($attack)
     {

--- a/app/Models/Attacks/ActionsOnObjectiveAttack.php
+++ b/app/Models/Attacks/ActionsOnObjectiveAttack.php
@@ -10,7 +10,7 @@ class ActionsOnObjectiveAttack extends Attack {
     public $_class_name             = "ActionsOnObjective";
     public $_tags                   = [];
     public $_prereqs                = ['PwnedAccess'];
-    public $_payload_choice         = 'StealRevenue';
+    public $_payload_choice         = 'ActionsOnObjective';
     public $_initial_success_chance = 0.90;
     public $_initial_detection_chance = 0.8;
     public $_initial_analysis_chance  = 0.2;

--- a/app/Models/Attacks/MalvertiseAttack.php
+++ b/app/Models/Attacks/MalvertiseAttack.php
@@ -14,6 +14,7 @@ class MalvertiseAttack extends Attack {
     public $_initial_success_chance = 0.4;
     public $_initial_detection_chance = 0.8;
     public $_initial_energy_cost    = 100;
+    public $_help_text              = "Infect a victim's machine with malware through an advertisement.";
 
     public $learn_page              = true;
 

--- a/app/Models/Attacks/SynFloodAttack.php
+++ b/app/Models/Attacks/SynFloodAttack.php
@@ -13,6 +13,7 @@ class SynFloodAttack extends Attack {
     public $_initial_success_chance = 0.6;
     public $_initial_detection_chance = 1;
     public $_initial_energy_cost    = 100;
+    public $_help_text              = "Send SYN packets to host to overwhelm servers.";
 
     public $learn_page              = true;
 

--- a/app/Models/Bonus.php
+++ b/app/Models/Bonus.php
@@ -155,14 +155,14 @@ class Bonus extends Model
             "You have " . $this->percentAnalDeducted. "% less chance of being analyzed by target. ";
         if(in_array("DifficultyDeduction", $this->tags))  $desc = $desc .  
             "It is " . $this->percentDiffDeducted. "% easier to be successful attacking the target. ";
-        if(in_array("OneTurnOnly", $this->tags))  $desc = $desc . 
-            "Bonus only lasts until next turn. ";
         if(in_array("ChanceToRemove", $this->tags))  $desc = $desc . 
             "Has a " . $this->removalChance . "% chance to be automatically removed each turn. ";
         if(in_array("PayToRemove", $this->tags))  $desc = $desc . 
             "Target can pay you ". $this->removalCostFactor . " times their per turn revenue to remove this bonus. ";
         elseif(in_array("UntilAnalyzed", $this->tags))  $desc = $desc .  
             "Bonus lasts until the target analyzes the attack.";
+        elseif(in_array("OneTurnOnly", $this->tags))  $desc = $desc . 
+            "Bonus only lasts until next turn. ";
         else  $desc = $desc .  "Decrements by 5% each turn.";
         return $desc;
     }
@@ -183,14 +183,14 @@ class Bonus extends Model
             "You have " . $this->percentAnalDeducted . "% less chance of analyzing this attacker. ";
         if(in_array("DifficultyDeduction", $this->tags))  $desc = $desc .  
             "It is " . $this->percentDiffDeducted . "% easier for the attacker to be successful against you. ";
-        if(in_array("OneTurnOnly", $this->tags))  $desc = $desc . 
-            "Bonus only lasts until next turn. ";
         if(in_array("ChanceToRemove", $this->tags))  $desc = $desc . 
             "You have a " . $this->removalChance . "% chance to automatically remove this each turn. ";
         if(in_array("PayToRemove", $this->tags))  $desc = $desc . 
             "You can pay the attacker " . $this->removalCostFactor . " times your per turn revenue to remove this bonus. ";
         elseif(in_array("UntilAnalyzed", $this->tags))  $desc = $desc .  
             "Bonus lasts until you analyze the attack.";
+        elseif(in_array("OneTurnOnly", $this->tags))  $desc = $desc . 
+            "Bonus only lasts until next turn. ";
         else  $desc = $desc .  "Decrements by 5% each turn.";
         return $desc;
     }

--- a/app/Models/Bonus.php
+++ b/app/Models/Bonus.php
@@ -141,8 +141,8 @@ class Bonus extends Model
 
     public function getTeamDescription(){
         $desc = "";
-        if(in_array("RevenueSteal",$this->tags)) $desc += 
-            "Steals 10% of target's revenue made each turn. ";
+        if(in_array("RevenueSteal",$this->tags)) $desc = $desc . 
+            "Steals " . $this->percentRevStolen . "% of target's revenue made each turn. ";
         if(in_array("RevenueGeneration", $this->tags)) $desc = $desc .
             "Your team generates $" . $this->revenueGenerated . " each turn. ";
         if(in_array("RevenueDeduction", $this->tags))  $desc = $desc .  
@@ -169,8 +169,8 @@ class Bonus extends Model
 
     public function getTargetDescription(){
         $desc = "";
-        if(in_array("RevenueSteal",$this->tags)) $desc += 
-            "Attacker steals 10% of your revenue made each turn. ";
+        if(in_array("RevenueSteal",$this->tags)) $desc = $desc .  
+            "Attacker steals " . $this->percentRevStolen . "% of your revenue made each turn. ";
         if(in_array("RevenueGeneration", $this->tags)) $desc = $desc .
             "The attacking team generates $" . $this->revenueGenerated . " each turn. This is not stolen. ";
         if(in_array("RevenueDeduction", $this->tags))  $desc = $desc .  

--- a/app/Models/Bonus.php
+++ b/app/Models/Bonus.php
@@ -99,15 +99,15 @@ class Bonus extends Model
         if(in_array("RevenueGeneration", $this->tags)){
             $redteam->changeBalance($this->revenueGenerated);
         }
-        if(in_array("OneTurnOnly", $this->tags)){
-            $this->destroy($this->id);
-            return;
-        }
         if(in_array("AddTokens", $this->tags)){
             $tokenQty = $redteam->getTokenQuantity($blueteam->name, 1);
             if ($tokenQty < 5){
                 $redteam->addToken($blueteam->name, 1);
             }
+        }
+        if(in_array("OneTurnOnly", $this->tags)){
+            $this->destroy($this->id);
+            return;
         }
         if(in_array("ChanceToRemove", $this->tags)){
             $rand = rand(1, 100);

--- a/app/Models/Bonus.php
+++ b/app/Models/Bonus.php
@@ -24,7 +24,8 @@ class Bonus extends Model
         'percentAnalDeducted', 
         'percentRemoval',
         'removalCostFactor',
-        'revenueGenerated'
+        'revenueGenerated',
+        'percentRevStolen'
     ];
     protected $casts = [ 'tags' => 'array']; // casts "json" database column to array and back
 
@@ -43,6 +44,7 @@ class Bonus extends Model
     public $_removalCostFactor = 1;
     public $_attack_id = null;
     public $_revenue_generated = 0;
+    public $_percent_rev_stolen = 0;
 
     function __construct() {
        $this->tags = $this->_tags;
@@ -60,6 +62,7 @@ class Bonus extends Model
        $this->attack_id = $this->_attack_id;
        $this->percentRevToRemove = $this->_percent_rev_remove;
        $this->revenueGenerated = $this->_revenue_generated;
+       $this->percentRevStolen = $this->_percent_rev_stolen;
     }
 
     public static function createBonus($team_id, $tags){
@@ -92,7 +95,7 @@ class Bonus extends Model
         }
         if(in_array("RevenueSteal", $this->tags)){
             $revGain = $blueteam->getPerTurnRevenue();
-            $amount = $revGain * 0.1;
+            $amount = $revGain * ($this->percentRevStolen * 0.01);
             $blueteam->changeBalance(-1* $amount);
             $redteam->changeBalance($amount);
         }

--- a/app/Models/Bonus.php
+++ b/app/Models/Bonus.php
@@ -13,7 +13,19 @@ class Bonus extends Model
      *
      * @var array
      */
-    protected $fillable = [ 'team_id', 'target_id','payload_name','percentRevDeducted', 'percentRepDeducted', 'percentDiffDeducted', 'percentDetDeducted', 'percentAnalDeducted'];
+    protected $fillable = [ 
+        'team_id', 
+        'target_id',
+        'payload_name',
+        'percentRevDeducted', 
+        'percentRepDeducted', 
+        'percentDiffDeducted', 
+        'percentDetDeducted', 
+        'percentAnalDeducted', 
+        'percentRemoval',
+        'removalCostFactor',
+        'revenueGenerated'
+    ];
     protected $casts = [ 'tags' => 'array']; // casts "json" database column to array and back
 
     public $_tags    = [];

--- a/app/Models/Inventory.php
+++ b/app/Models/Inventory.php
@@ -116,7 +116,7 @@ class Inventory extends Model
 
     public function getAssetName(){
         if ($this->asset_name != 'AccessToken') { 
-            return $this->asset_name;
+            return Asset::get($this->asset_name)->name;
         }
         else {
             if ($this->level == 1) { return "Basic Access";}

--- a/app/Models/Inventory.php
+++ b/app/Models/Inventory.php
@@ -113,4 +113,15 @@ class Inventory extends Model
         }
         return true;
     }
+
+    public function getAssetName(){
+        if ($this->asset_name != 'AccessToken') { 
+            return $this->asset_name;
+        }
+        else {
+            if ($this->level == 1) { return "Basic Access";}
+            elseif ($this->level == 2) { return "Private Access";}
+            elseif ($this->level ==3 ) { return "Pwnd Access";}
+        }
+    }
 }

--- a/app/Models/Payloads/ActionsOnObjective.php
+++ b/app/Models/Payloads/ActionsOnObjective.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models\Payloads;
+
+use App\Models\Payload;
+use App\Models\Team;
+
+class ActionsOnObjective extends Payload 
+{
+
+    public $_name = "Actions on objective";
+    public $_class_name = "ActionsOnObjective";
+    public $_tags = [];
+
+    public function onAttackComplete($attack){
+        parent::onAttackComplete($attack);
+        $bonus = parent::createBonus($attack);
+        $bonus->tags = ['RevenueSteal'];
+        $bonus->percentRevStolen = 10;
+        $bonus->save();
+    }
+}

--- a/app/Models/Payloads/Eavesdropping.php
+++ b/app/Models/Payloads/Eavesdropping.php
@@ -21,12 +21,14 @@ class Eavesdropping extends Payload
             $bonus->tags = ['DetectionDeduction','DifficultyDeduction'];
             $bonus->percentDetDeducted = 20;
             $bonus->percentDiffDeducted = 20;
+            $bonus->save();
         }
         $rand = rand(1,100);
         if ($rand <= 50) { //50% fininfo, steal 40% per turn rev for one turn
             $bonus = parent::createBonus($attack);
             $bonus->tags = ['OneTurnOnly', 'RevenueSteal'];
             $bonus->percentRevStolen = 40;
+            $bonus->save();
         }
         $rand = rand(1,100);
         if ($rand <= 40) { //40% basic access

--- a/app/Models/Payloads/Eavesdropping.php
+++ b/app/Models/Payloads/Eavesdropping.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models\Payloads;
+
+use App\Models\Payload;
+use App\Models\Team;
+
+class Eavesdropping extends Payload 
+{
+
+    public $_name = "Eavesdropping";
+    public $_class_name = "Eavesdropping";
+    public $_tags = [];
+
+    public function onAttackComplete($attack){
+        parent::onAttackComplete($attack);
+
+        $rand = rand(1,100);
+        if ($rand <= 50) { //50% secinfo, reduces detection and difficulty 
+            $bonus = parent::createBonus($attack);
+            $bonus->tags = ['DetectionDeduction','DifficultyDeduction'];
+            $bonus->percentDetDeducted = 20;
+            $bonus->percentDiffDeducted = 20;
+        }
+        $rand = rand(1,100);
+        if ($rand <= 50) { //50% fininfo, steal 40% per turn rev for one turn
+            $bonus = parent::createBonus($attack);
+            $bonus->tags = ['OneTurnOnly', 'RevenueSteal'];
+            $bonus->percentRevStolen = 40;
+        }
+        $rand = rand(1,100);
+        if ($rand <= 40) { //40% basic access
+            $redteam = Team::find($attack->redteam);
+            $blueteam = Team::find($attack->blueteam);
+            $redteam->addToken($blueteam->name, 1);
+        }
+        $rand = rand(1,100);
+        if ($rand <= 10) { //10% priv access
+            $redteam = Team::find($attack->redteam);
+            $blueteam = Team::find($attack->blueteam);
+            $redteam->addToken($blueteam->name, 2);
+        }
+    }
+}

--- a/app/Models/Payloads/Fuzzing.php
+++ b/app/Models/Payloads/Fuzzing.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models\Payloads;
+
+use App\Models\Payload;
+use App\Models\Team;
+
+class Fuzzing extends Payload 
+{
+
+    public $_name = "Fuzzing";
+    public $_class_name = "Fuzzing";
+    public $_tags = [];
+
+    public function onAttackComplete($attack){
+        parent::onAttackComplete($attack);
+
+        $rand = rand(1,100);
+        if ($rand <= 50) { //50% Confusion payload executes
+            $payload = new Confusion;
+            $payload->onAttackComplete($attack);
+        }
+        else { //50% get priv access token
+            $redteam = Team::find($attack->redteam);
+            $blueteam = Team::find($attack->blueteam);
+            $redteam->addToken($blueteam->name, 2);
+        }
+    }
+}

--- a/app/Models/Payloads/StolenLaptop.php
+++ b/app/Models/Payloads/StolenLaptop.php
@@ -21,12 +21,14 @@ class StolenLaptop extends Payload
             $bonus->tags = ['DetectionDeduction','DifficultyDeduction'];
             $bonus->percentDetDeducted = 20;
             $bonus->percentDiffDeducted = 20;
+            $bonus->save();
         }
         $rand = rand(1,100);
         if ($rand <= 50) { //50% fininfo, steal 40% per turn rev for one turn
             $bonus = parent::createBonus($attack);
             $bonus->tags = ['OneTurnOnly', 'RevenueSteal'];
             $bonus->percentRevStolen = 40;
+            $bonus->save();
         }
         $rand = rand(1,100);
         if ($rand <= 80) { //80% basic access

--- a/app/Models/Payloads/StolenLaptop.php
+++ b/app/Models/Payloads/StolenLaptop.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models\Payloads;
+
+use App\Models\Payload;
+use App\Models\Team;
+
+class StolenLaptop extends Payload 
+{
+
+    public $_name = "Stolen Laptop";
+    public $_class_name = "StolenLaptop";
+    public $_tags = [];
+
+    public function onAttackComplete($attack){
+        parent::onAttackComplete($attack);
+
+        $rand = rand(1,100);
+        if ($rand <= 25) { //25% secinfo, reduces detection and difficulty 
+            $bonus = parent::createBonus($attack);
+            $bonus->tags = ['DetectionDeduction','DifficultyDeduction'];
+            $bonus->percentDetDeducted = 20;
+            $bonus->percentDiffDeducted = 20;
+        }
+        $rand = rand(1,100);
+        if ($rand <= 50) { //50% fininfo, steal 40% per turn rev for one turn
+            $bonus = parent::createBonus($attack);
+            $bonus->tags = ['OneTurnOnly', 'RevenueSteal'];
+            $bonus->percentRevStolen = 40;
+        }
+        $rand = rand(1,100);
+        if ($rand <= 80) { //80% basic access
+            $redteam = Team::find($attack->redteam);
+            $blueteam = Team::find($attack->blueteam);
+            $redteam->addToken($blueteam->name, 1);
+        }
+        $rand = rand(1,100);
+        if ($rand <= 20) { //20% priv access
+            $redteam = Team::find($attack->redteam);
+            $blueteam = Team::find($attack->blueteam);
+            $redteam->addToken($blueteam->name, 2);
+        }
+        $rand = rand(1,100);
+        if ($rand <= 1) { //1% pwned access
+            $redteam = Team::find($attack->redteam);
+            $blueteam = Team::find($attack->blueteam);
+            $redteam->addToken($blueteam->name, 3);
+        }
+    }
+}

--- a/app/Models/Payloads/Xss.php
+++ b/app/Models/Payloads/Xss.php
@@ -16,6 +16,7 @@ class Xss extends Payload
         parent::onAttackComplete($attack);
         $bonus = parent::createBonus($attack);
         $bonus->tags = ["UntilAnalyzed", "RevenueSteal"];
+        $bonus->percentRevStolen = 10;
         $bonus->save();
     }
 }

--- a/database/migrations/2021_01_25_232356_create_bonuses_table.php
+++ b/database/migrations/2021_01_25_232356_create_bonuses_table.php
@@ -30,6 +30,7 @@ class CreateBonusesTable extends Migration
             $table->integer('removalChance')->nullable();
             $table->integer('removalCostFactor')->nullable(); //removal cost compared to perTurnRevenue. 2 = twice perTurnRev
             $table->integer('revenueGenerated')->nullable();
+            $table->integer('percentRevStolen')->nullable();
             $table->timestamps();
         });
     }

--- a/resources/views/partials/inventory_table.blade.php
+++ b/resources/views/partials/inventory_table.blade.php
@@ -27,7 +27,7 @@
                     title="{{$invAsset->description}}
                     <?php if($invAsset->ownership_cost > 0) echo " Ownership Cost: " . $invAsset->ownership_cost;
                     else echo "Revenue Gained Per Turn: " . (-1 * $invAsset->ownership_cost); ?>"
-                    >{{ $invAsset->name }}</td>
+                    >{{ $inv->getAssetName() }}</td>
                 <td>{{$inv->quantity }}</td>
                 @if(in_array("Targeted", $invAsset->tags)) 
                     @if($inv->info != null)

--- a/tests/Unit/BonusTest.php
+++ b/tests/Unit/BonusTest.php
@@ -115,6 +115,7 @@ class BonusTest extends TestCase {
         $tags = ["RevenueSteal"];
         $bonus = $this->createBonus($team->id, $tags);
         $bonus->target_id = $blueteam->id;
+        $bonus->percentRevStolen = 10;
         $bonus->update();
         $this->assertTrue(in_array("RevenueSteal", $bonus->tags));
         $this->assertEquals($team->id, $bonus->team_id);

--- a/tests/Unit/PayloadTest.php
+++ b/tests/Unit/PayloadTest.php
@@ -278,6 +278,11 @@ class PayloadTest extends TestCase {
             $this->assertEquals($blueteam->id, $bonus->target_id);
             $this->assertTrue(in_array('DetectionDeduction', $bonus->tags) || in_array('OneTurnOnly', $bonus->tags));
         }
+        $inv = $redteam->inventories();
+        $this->assertLessThanOrEqual(2, count($inv));
+        foreach($inv as $asset){
+            $this->assertEquals('AccessToken', $asset->asset_name);
+        }
     }
 
     public function testStolenLaptopPayload(){

--- a/tests/Unit/PayloadTest.php
+++ b/tests/Unit/PayloadTest.php
@@ -22,6 +22,7 @@ use App\Models\Payloads\WebsiteDefacement;
 use App\Models\Payloads\Keylogger;
 use App\Models\Payloads\Ransomware;
 use App\Models\Payloads\MaliciousInsider;
+use App\Models\Payloads\StolenLaptop;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class PayloadTest extends TestCase {
@@ -276,6 +277,26 @@ class PayloadTest extends TestCase {
             $this->assertEquals($redteam->id, $bonus->team_id);
             $this->assertEquals($blueteam->id, $bonus->target_id);
             $this->assertTrue(in_array('DetectionDeduction', $bonus->tags) || in_array('OneTurnOnly', $bonus->tags));
+        }
+    }
+
+    public function testStolenLaptopPayload(){
+        $attack = $this->createTeamsAndAttack();
+        $redteam = Team::find($attack->redteam);
+        $blueteam = Team::find($attack->blueteam);
+        $payload = new StolenLaptop;
+        $payload->onAttackComplete($attack);
+        $bonuses = $redteam->getBonuses();
+        $this->assertLessThanOrEqual(2, count($bonuses));
+        foreach($bonuses as $bonus) {
+            $this->assertEquals($redteam->id, $bonus->team_id);
+            $this->assertEquals($blueteam->id, $bonus->target_id);
+            $this->assertTrue(in_array('DetectionDeduction', $bonus->tags) || in_array('OneTurnOnly', $bonus->tags));
+        }
+        $inv = $redteam->inventories();
+        $this->assertLessThanOrEqual(3, count($inv));
+        foreach($inv as $asset){
+            $this->assertEquals('AccessToken', $asset->asset_name);
         }
     }
 }

--- a/tests/Unit/PayloadTest.php
+++ b/tests/Unit/PayloadTest.php
@@ -14,6 +14,7 @@ use App\Models\Payloads\Dos;
 use App\Models\Payloads\Destruction;
 use App\Models\Payloads\BasicAccess;
 use App\Models\Payloads\Confusion;
+use App\Models\Payloads\Eavesdropping;
 use App\Models\Payloads\PrivAccess;
 use App\Models\Payloads\Evasion;
 use App\Models\Payloads\InformationStealing;
@@ -263,4 +264,18 @@ class PayloadTest extends TestCase {
         $this->assertEquals($blueteam->name, $access->info);
     }
 
+    public function testEavesdroppingPayload(){
+        $attack = $this->createTeamsAndAttack();
+        $redteam = Team::find($attack->redteam);
+        $blueteam = Team::find($attack->blueteam);
+        $payload = new Eavesdropping;
+        $payload->onAttackComplete($attack);
+        $bonuses = $redteam->getBonuses();
+        $this->assertLessThanOrEqual(2, count($bonuses));
+        foreach($bonuses as $bonus) {
+            $this->assertEquals($redteam->id, $bonus->team_id);
+            $this->assertEquals($blueteam->id, $bonus->target_id);
+            $this->assertTrue(in_array('DetectionDeduction', $bonus->tags) || in_array('OneTurnOnly', $bonus->tags));
+        }
+    }
 }

--- a/tests/Unit/PayloadTest.php
+++ b/tests/Unit/PayloadTest.php
@@ -74,6 +74,7 @@ class PayloadTest extends TestCase {
         $this->assertEquals(2, count($bonus->tags));
         $this->assertTrue(in_array("UntilAnalyzed", $bonus->tags));
         $this->assertTrue(in_array("RevenueSteal", $bonus->tags));
+        $this->assertEquals(10, $bonus->percentRevStolen);
     }
 
     public function testDosPayload(){

--- a/tests/Unit/PayloadTest.php
+++ b/tests/Unit/PayloadTest.php
@@ -17,6 +17,7 @@ use App\Models\Payloads\Confusion;
 use App\Models\Payloads\Eavesdropping;
 use App\Models\Payloads\PrivAccess;
 use App\Models\Payloads\Evasion;
+use App\Models\Payloads\Fuzzing;
 use App\Models\Payloads\InformationStealing;
 use App\Models\Payloads\WebsiteDefacement;
 use App\Models\Payloads\Keylogger;
@@ -302,6 +303,26 @@ class PayloadTest extends TestCase {
         $this->assertLessThanOrEqual(3, count($inv));
         foreach($inv as $asset){
             $this->assertEquals('AccessToken', $asset->asset_name);
+        }
+    }
+
+    public function testFuzzingPayload(){
+        $attack = $this->createTeamsAndAttack();
+        $redteam = Team::find($attack->redteam);
+        $payload = new Fuzzing;
+        $payload->onAttackComplete($attack);
+        $bonus = $redteam->getBonuses()->first();
+
+        if ($bonus != null){
+            $this->assertTrue(in_array("DetectionDeduction", $bonus->tags));
+            $this->assertEquals(20, $bonus->percentDetDeducted);
+            $this->assertTrue(in_array("AnalysisDeduction", $bonus->tags));
+            $this->assertEquals(20, $bonus->percentAnalDeducted);
+        }
+        else {
+            $inv = $redteam->inventories()->first();
+            $this->assertEquals('AccessToken', $inv->asset_name);
+            $this->assertEquals(2, $inv->level);
         }
     }
 }

--- a/tests/Unit/PayloadTest.php
+++ b/tests/Unit/PayloadTest.php
@@ -8,6 +8,7 @@ use App\Models\Team;
 use App\Models\User;
 use App\Models\Bonus;
 use App\Models\Attack;
+use App\Models\Payloads\ActionsOnObjective;
 use App\Models\Payloads\AdWare;
 use App\Models\Payloads\Xss;
 use App\Models\Payloads\Dos;
@@ -324,5 +325,16 @@ class PayloadTest extends TestCase {
             $this->assertEquals('AccessToken', $inv->asset_name);
             $this->assertEquals(2, $inv->level);
         }
+    }
+
+    public function testActionsOnObjectivePayload(){
+        $attack = $this->createTeamsAndAttack();
+        $redteam = Team::find($attack->redteam);
+        $payload = new ActionsOnObjective;
+        $payload->onAttackComplete($attack);
+        $bonus = $redteam->getBonuses()->first();
+        $this->assertEquals($redteam->id, $bonus->team_id);
+        $this->assertTrue(in_array("RevenueSteal", $bonus->tags));
+        $this->assertEquals(10, $bonus->percentRevStolen);
     }
 }


### PR DESCRIPTION
Added missing payloads and tests for them. Some assets were missing descriptions, added those to prevent the "Abstract class" from appearing. Slightly changed inventory table to show what kind of access token is owned (Basic, Priv, Pwnd) because it was difficult to tell what kind of access tokens the team owned imo.